### PR TITLE
Hotfix 20221214 abort error brucekomike

### DIFF
--- a/composables/animation.ts
+++ b/composables/animation.ts
@@ -3,7 +3,7 @@
  * @param elements - HTML DOM 元素。
  * @returns 是否有移除动画。
  */
- export function removeExistAnimations(...elements: Element[]) {
+export function removeExistAnimations(...elements: Element[]) {
 	let hasExistAnimations = false;
 	for (const element of elements) {
 		const existAnimations = element.getAnimations();


### PR DESCRIPTION
在取消动画前结束动画以避免报错
参考:https://developer.mozilla.org/en-US/docs/Web/API/Animation/cancel