### PR TITLE
:sparkles: 增加头像上传功能，完善登录/登出流程

### DIFF
--- a/components/ImageCropper.vue
+++ b/components/ImageCropper.vue
@@ -1,53 +1,124 @@
+<!-- 基于 vue-cropper 的图片切割组件 -->
 <script setup lang="ts">
 	import { VueCropper } from "vue-cropper";
 	import cropTestImage from "assets/images/av820864307.jpg";
 
 	const props = withDefaults(defineProps<{
-		/** 图片路径。 */
+		/** 裁剪图片的地址 */
 		image?: string;
+		/** 裁剪生成图片的质量, 0.1 ~ 1 */
+		outputSize?: number;
+		/** 裁剪生成图片的格式 */
+		outputType?: "jpeg" | "png" | "webp";
+		/** 裁剪框的大小信息 */
+		info?: boolean;
+		/** 图片是否允许滚轮缩放 */
+		canScale?: boolean;
+		/** 是否默认生成截图框 */
+		autoCrop?: boolean;
+		/** 默认生成截图框宽度 */
+		autoCropWidth?: number;
+		/** 默认生成截图框高度 */
+		autoCropHeight?: number;
+		/** 是否开启截图框宽高固定比例 */
+		fixed?: boolean;
+		/** 截图框的宽高比例, 开启 fixed 才能生效 */
+		fixedNumber?: [number, number];
+		/** 是否输出原图比例的截图 */
+		full?: boolean;
+		/** 固定截图框大小 */
+		fixedBox?: boolean;
+		/** 上传图片是否可以移动 */
+		canMove?: boolean;
+		/** 截图框能否拖动 */
+		canMoveBox?: boolean;
+		/** 上传图片按照原始比例渲染 */
+		original?: boolean;
+		/** 截图框是否被限制在图片里面 */
+		centerBox?: boolean;
+		/** 是否按照设备的 dpr 输出等比例图片 */
+		high?: boolean;
+		/** true 为展示真实输出图片宽高 false 展示看到的截图框宽高 */
+		infoTrue?: boolean;
+		/** 限制图片最大宽度和高度, 0 ~ max */
+		maxImgSize?: number;
+		/** 图片根据截图框输出比例倍数, 0 ~ max (建议不要太大不然会卡死的呢) */
+		enlarge?: number;
+		/** 图片默认渲染方式 */
+		mode?: "contain" | "cover" | string;
+		/** 裁剪框限制最小区域 */
+		limitMinSize?: number | [] | string;
+		/** 导出时背景颜色填充 */
+		fillColor?: string | void;
 	}>(), {
 		image: cropTestImage,
-	});
-
-	const vueCropperOption = reactive({
-		img: props.image,
-		size: 1,
-		full: false,
+		outputSize: 1,
 		outputType: "png",
+		info: true,
+		full: false,
+		fixed: false,
 		canMove: true,
 		fixedBox: false,
 		original: false,
 		canMoveBox: true,
 		autoCrop: true,
-		// 只有自动截图开启 宽度高度才生效
-		autoCropWidth: 750,
-		autoCropHeight: 340,
+		// autoCropWidth: 750, // 只有自动截图开启 宽度高度才生效
+		// autoCropHeight: 340, // 只有自动截图开启 宽度高度才生效
 		centerBox: true,
 		high: true,
-		max: 99999,
+		maxImgSize: 99999,
+		mode: "contain",
+	});
+
+	const cropper = ref();
+	/**
+	 * 获取被裁减的图片结果
+	 * @returns Blob 格式存储的被裁剪后的图片
+	 */
+	const getCropBlobData = (): Promise<Blob> => {
+		return new Promise((resolve, reject) => {
+			if (!cropper.value) {
+				reject(new Error("Cropper is not initialized"));
+				return;
+			}
+
+			cropper.value.getCropBlob((data: unknown) => {
+				const imageBlobData = data as Blob;
+				if (imageBlobData)
+					resolve(imageBlobData);
+				else
+					reject(new Error("No image data found"));
+			});
+		});
+	};
+
+	defineExpose({
+		getCropBlobData,
 	});
 </script>
 
 <template>
 	<ClientOnly>
 		<VueCropper
-			:img="vueCropperOption.img"
-			:outputSize="vueCropperOption.size"
-			:outputType="vueCropperOption.outputType"
-			:info="true"
-			:full="vueCropperOption.full"
-			:fixed="false"
-			:canMove="vueCropperOption.canMove"
-			:canMoveBox="vueCropperOption.canMoveBox"
-			:fixedBox="vueCropperOption.fixedBox"
-			:original="vueCropperOption.original"
-			:autoCrop="vueCropperOption.autoCrop"
-			:autoCropWidth="vueCropperOption.autoCropWidth"
-			:autoCropHeight="vueCropperOption.autoCropHeight"
-			:centerBox="vueCropperOption.centerBox"
-			:high="vueCropperOption.high"
-			mode="contain"
-			:maxImgSize="vueCropperOption.max"
+			ref="cropper"
+			:img="image"
+			:outputSize="outputSize"
+			:outputType="outputType"
+			:info="info"
+			:full="full"
+			:fixed="fixed"
+			:fixedNumber="fixedNumber"
+			:canMove="canMove"
+			:canMoveBox="canMoveBox"
+			:fixedBox="fixedBox"
+			:original="original"
+			:autoCrop="autoCrop"
+			:autoCropWidth="autoCropWidth"
+			:autoCropHeight="autoCropHeight"
+			:centerBox="centerBox"
+			:high="high"
+			:mode="mode"
+			:maxImgSize="maxImgSize"
 		>
 			<template #loading>
 				<ProgressRing />

--- a/composables/api/Common/getCorrectUri.ts
+++ b/composables/api/Common/getCorrectUri.ts
@@ -1,7 +1,9 @@
 /**
- * 根据当前环境（开发或生产）确定正确的后端地址。
+ * 根据当前环境（开发或生产）返回正确的后端地址。
  * @returns 正确的后端地址。
  */
 export default function getCorrectUri() {
+	// URI 必须包含协议头，不建议在结尾添加斜线 '/'
+	// eg. https://localhost:9999
 	return environment.production ? "https://rosales.kirakira.moe" : "https://localhost:9999";
 }

--- a/composables/api/Common/index.ts
+++ b/composables/api/Common/index.ts
@@ -73,3 +73,59 @@ export async function post(url: string, body: unknown, requestOptions: RequestOb
 		throw error;
 	}
 }
+
+/**
+ * 发送 PUT 请求向 R2 上传文件
+ * @param signedUrl R2 用于上传文件的预编译 URL
+ * @param body 上传的文件的 Blob
+ * @param contentType 请求负载的数据的媒体类型，例如：'application/json', 'image/png' 等。详细的 Content-Type 请参照本文件最下方的注释
+ * @param timeout 请求超时时间（毫秒），默认：30000ms
+ * @returns 请求结果，上传成功 true，否则 false
+ */
+export async function uploadFile2R2(signedUrl: string, body: Blob, contentType: string, timeout?: number): Promise<void> {
+	try {
+		await fetchWithTimeout(signedUrl, {
+			method: "PUT",
+			mode: "cors",
+			headers: {
+				"Content-Type": contentType,
+				"Access-Control-Allow-Origin": "*",
+			},
+			body,
+		}, timeout);
+	} catch (error) {
+		console.error("ERROR", `something wrong in 'uploadFile2R2', URL: ${signedUrl}`, error); // TODO Remove Console Output?
+		throw error;
+	}
+}
+
+// 以下为典型的 Content-Type HTTP 标头
+//
+// 文本格式:
+// text/html: 用于 HTML 文档。
+// text/plain: 纯文本文件。
+// text/css: CSS 样式表。
+// text/javascript: JavaScript 代码。
+//
+// 图像格式:
+// image/jpeg: JPEG 图像。
+// image/png: PNG 图像。
+// image/gif: GIF 图像。
+// image/svg+xml: SVG 矢量图像。
+//
+// 应用程序和文档格式:
+// application/json: JSON 数据格式。
+// application/xml: XML 数据格式。
+// application/pdf: PDF 文档。
+// application/msword: Microsoft Word 文档。
+// application/vnd.ms-excel: Microsoft Excel 文档。
+//
+// 音频和视频格式:
+// audio/mpeg: MP3 音频。
+// audio/ogg: Ogg 音频。
+// video/mp4: MP4 视频。
+// video/x-msvideo: AVI 视频。
+//
+// 其他格式:
+// application/octet-stream: 任意的二进制数据。
+// multipart/form-data: 用于表单数据，尤其是包含文件上传时。

--- a/composables/api/User/UserController.ts
+++ b/composables/api/User/UserController.ts
@@ -1,6 +1,6 @@
-import { get, post } from "api/Common";
+import { get, post, uploadFile2R2 } from "api/Common";
 import getCorrectUri from "api/Common/getCorrectUri";
-import type { CheckUserTokenResponseDto, GetUserInfoByUidResponseDto, UpdateUserEmailRequestDto, UserExistsCheckRequestDto, UserExistsCheckResponseDto, UserLoginRequestDto, UserLoginResponseDto, UserRegistrationRequestDto, UserRegistrationResponseDto } from "./UserControllerDto";
+import type { CheckUserTokenResponseDto, GetUserAvatarUploadSignedUrlResultDto, GetUserInfoByUidResponseDto, UpdateUserEmailRequestDto, UserExistsCheckRequestDto, UserExistsCheckResponseDto, UserLoginRequestDto, UserLoginResponseDto, UserRegistrationRequestDto, UserRegistrationResponseDto } from "./UserControllerDto";
 
 const BACK_END_URL = getCorrectUri();
 const USER_API_URI = `${BACK_END_URL}/user`;
@@ -44,12 +44,22 @@ export const updateUserEmail = async (updateUserEmailRequest: UpdateUserEmailReq
 };
 
 /**
- * 获取用户信息，前提是 token 中包含正确的 uid 和 token
+ * 获取用户信息，前提是 token 中包含正确的 uid 和 token，同时丰富全局变量中的用户信息
  * @returns 用户信息
  */
 export const getUserInfo = async (): Promise<GetUserInfoByUidResponseDto> => {
 	// TODO use { credentials: "include" } to allow save cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
-	return await get(`${USER_API_URI}/info`, { credentials: "include" }) as GetUserInfoByUidResponseDto;
+	const userInfo = await get(`${USER_API_URI}/info`, { credentials: "include" }) as GetUserInfoByUidResponseDto;
+	const userInfoStore = useUserInfoStore();
+	if (userInfo.success) {
+		userInfoStore.isLogined = true;
+		userInfoStore.userAvatar = userInfo.result?.avatar || "";
+		userInfoStore.username = userInfo.result?.username || "User"; // TODO 使用多语言，为未设置用户名的用户提供国际化的缺省用户名
+		userInfoStore.gender = userInfo.result?.gender || "";
+		userInfoStore.signature = userInfo.result?.signature || "";
+		userInfoStore.tags = userInfo.result?.label || [];
+	}
+	return userInfo;
 };
 
 /**
@@ -63,9 +73,39 @@ export const checkUserToken = async (): Promise<CheckUserTokenResponseDto> => {
 
 /**
  * 用户登出
- * @returns 什么也不返回，但是会携带立即清除的 cookie 并覆盖圆本的 cookie
+ * @returns 什么也不返回，但是会携带立即清除的 cookie 并覆盖原本的 cookie，同时将全局变量中的用户信息置空
  */
 export const userLogout = async (): Promise<undefined> => {
 	// TODO use { credentials: "include" } to allow save cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
-	return await get(`${USER_API_URI}/logout`, { credentials: "include" }) as undefined;
+	await get(`${USER_API_URI}/logout`, { credentials: "include" }) as undefined;
+	const userInfoStore = useUserInfoStore();
+	userInfoStore.isLogined = false;
+	userInfoStore.userAvatar = "";
+	userInfoStore.username = "";
+	userInfoStore.gender = "";
+	userInfoStore.signature = "";
+	userInfoStore.tags = [];
+};
+
+/**
+ * 更新用户头像，并获取用于用户上传头像的预签名 URL, 上传限时 60 秒
+ */
+export const getUserAvatarUploadSignedUrl = async (): Promise<GetUserAvatarUploadSignedUrlResultDto> => {
+	return await get(`${USER_API_URI}/avatar/preUpload`, { credentials: "include" }) as GetUserAvatarUploadSignedUrlResultDto;
+};
+
+/**
+ * 根据预签名 URL 上传用户头像
+ * @param avatarBlobData 用 Blob 编码的用户头像文件
+ * @param signedUrl 预签名 URL
+ * @returns 是否上传成功，成功返回 true，失败返回 false
+ */
+export const uploadUserAvatar = async (avatarBlobData: Blob, signedUrl: string): Promise<boolean> => {
+	try {
+		await uploadFile2R2(signedUrl, avatarBlobData, "image/png", 60000);
+		return true;
+	} catch (error) {
+		console.error("用户头像上传失败，错误信息：", error, { avatarBlobData, signedUrl });
+		return false;
+	}
 };

--- a/composables/api/User/UserControllerDto.d.ts
+++ b/composables/api/User/UserControllerDto.d.ts
@@ -207,3 +207,15 @@ export type UserLogoutResponseDto = {
 	/** 附加的文本消息 */
 	message?: string;
 };
+
+/**
+ * 获取用于用户上传头像的预签名 URL
+ */
+export type GetUserAvatarUploadSignedUrlResultDto = {
+	/** 执行结果，程序执行成功，返回 true，程序执行失败，返回 false */
+	success: boolean;
+	/** 用于用户上传头像的预签名 URL */
+	userAvatarUploadSignedUrl?: string;
+	/** 附加的文本消息 */
+	message?: string;
+};

--- a/layouts/settings.vue
+++ b/layouts/settings.vue
@@ -16,7 +16,6 @@
 		if (logoutResult) {
 			useToast("用户已登出。", "success"); // TODO 使用多语言
 			useEvent("user:login", false);
-			userInfoStore.isLogined = false;
 		}
 	};
 

--- a/layouts/user-page.vue
+++ b/layouts/user-page.vue
@@ -18,7 +18,7 @@
 
 	// TODO nice copy pasta dude
 	const uid = currentUserUid();
-	const user = ref<GetUserInfoByUidResponseDto>();
+	// const user = ref<GetUserInfoByUidResponseDto>();
 
 	const isSelf = ref(false); // TODO 是否为登录用户本人。
 	const isFollowed = ref(false); // TODO
@@ -41,7 +41,7 @@
 	/** fetch the user profile data */
 	async function fetchData() {
 		// WARN 现在这个接口就只能获得当前登录用户的信息！
-		user.value = await api.user.getUserInfo();
+		await api.user.getUserInfo();
 	}
 
 	watch(data, fetchData, { deep: true });
@@ -52,7 +52,7 @@
 		set: async id => { await navigate(`/user/${uid}/${id}`); },
 	});
 
-	useHead({ title: user.value?.result?.username ? t.user_page.title_affix(user.value.result.username) : undefined });
+	useHead({ title: userInfoStore.username ? t.user_page.title_affix(userInfoStore.username) : undefined });
 </script>
 
 <template>
@@ -60,18 +60,18 @@
 		<div>
 			<div class="content">
 				<div class="user">
-					<UserAvatar :avatar="user?.result?.avatar || undefined" />
+					<UserAvatar :avatar="userInfoStore.userAvatar || undefined" />
 					<div class="texts">
 						<div class="names">
-							<span class="username">{{ user?.result?.username }}</span>
+							<span class="username">{{ userInfoStore.username }}</span>
 							<!-- <span v-if="memoParen" class="memo" :class="[memoParen]">{{ user?.bio }}</span> -->
 							<span class="icons">
-								<Icon v-if="user?.result?.gender === 'male'" name="male" class="male" />
-								<Icon v-else-if="user?.result?.gender === 'female'" name="female" class="female" />
-								<span v-else class="other-gender">{{ user?.result?.gender }}</span>
+								<Icon v-if="userInfoStore.gender === 'male'" name="male" class="male" />
+								<Icon v-else-if="userInfoStore.gender === 'female'" name="female" class="female" />
+								<span v-else class="other-gender">{{ userInfoStore.gender }}</span>
 							</span>
 						</div>
-						<div class="bio">{{ user?.result?.signature }}</div>
+						<div class="bio">{{ userInfoStore.signature }}</div>
 					</div>
 				</div>
 				<div class="actions">

--- a/stores/user-info.ts
+++ b/stores/user-info.ts
@@ -1,8 +1,18 @@
 export const useUserInfoStore = defineStore("user-info", () => {
 	/** 是否已经登录？ */
 	const isLogined = ref(false);
-	/** 用户名。 */
+	/** 当前登录的用户用户名。 */
 	const username = ref("");
+	/** 当前登录的用户的头像 */
+	const userAvatar = ref("");
+	/** 当前登录的用户的性别 */
+	const gender = ref("");
+	/** 当前登录的用户的个性签名或简介 */
+	const signature = ref("");
+	/** 当前登录的用户的生日 */
+	const birthday = ref(0);
+	/** 当前登录的用户的标签 */
+	const tags = ref<UserLabelSchema[]>([]);
 
-	return { isLogined, username };
+	return { isLogined, username, userAvatar, gender, signature, birthday, tags };
 });


### PR DESCRIPTION
1. 增加头像上传功能
    可以在设置页裁剪图片并上传了。（还不支持本地上传，因为我还没看切图组件怎么拿到上传的图片，现在只有艾拉的图）
2. 完善登录/登出流程
    用户信息现在在全局状态中存储，只要调用 "获取用户信息" 的请求，就会更新全局状态；反之调用 ”登出“ 请求就会清空。

btw: @Aira-Sakuranomiya 我动了切图组件的代码