### PR TITLE
:sparkles: 实现基础的搜索功能（关键字搜索）

### DIFF
--- a/composables/api/Video/VideoController.ts
+++ b/composables/api/Video/VideoController.ts
@@ -47,3 +47,19 @@ export const getVideoByUid = async (getVideoByUidRequest: GetVideoByUidRequestDt
 	} else
 		return { success: false, message: "未提供 UID", videosCount: 0, videos: [] };
 };
+
+/**
+ * 根据关键字搜索视频
+ * @param searchVideoByKeywordRequest 根据关键字搜索视频的请求参数
+ * @returns 根据关键字搜索视频的请求响应结果
+ */
+export const searchVideoByKeyword = async (searchVideoByKeywordRequest: SearchVideoByKeywordRequestDto): Promise<SearchVideoByKeywordResponseDto> => {
+	if (searchVideoByKeywordRequest && searchVideoByKeywordRequest.keyword) {
+		const { data: result } = await useFetch<SearchVideoByKeywordResponseDto>(`${VIDEO_API_URI}/search?keyword=${searchVideoByKeywordRequest.keyword}`);
+		if (result.value)
+			return result.value;
+		else
+			return { success: false, message: "根据关键字搜索视频失败", videosCount: 0, videos: [] };
+	} else
+		return { success: false, message: "未提供关键字", videosCount: 0, videos: [] };
+};

--- a/composables/api/Video/VideoControllerDto.d.ts
+++ b/composables/api/Video/VideoControllerDto.d.ts
@@ -171,6 +171,18 @@ export type GetVideoByUidRequestDto = {
 };
 
 /**
- * 从 UID 获取视频的请求响应结果
+ * 从 UID 获取视频的请求的响应结果
  */
 export type GetVideoByUidResponseDto = ThumbVideoResponseDto & {};
+
+/**
+ * 根据关键字搜索视频的请求参数
+ */
+export type SearchVideoByKeywordRequestDto = {
+	keyword: string;
+};
+
+/**
+ * 根据关键字搜索视频的响应结果
+ */
+export type SearchVideoByKeywordResponseDto = ThumbVideoResponseDto & {};

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -88,9 +88,12 @@
 
 	await searchVideo();
 
+	// 向路由中更新搜索的关键字
 	watch(() => data.search, search => {
 		router.push({ path: route.path, query: { ...route.query, query: search || undefined } });
 	});
+
+	// 向路由中更新当前的搜索模式
 	watch(() => searchMode.value, searchMode => {
 		router.push({ path: route.path, query: { ...route.query, mode: searchMode || undefined } });
 	});
@@ -111,7 +114,7 @@
 						:uploader="video.uploader ?? ''"
 						:uploaderId="video.uploaderId"
 						:image="video.image"
-						:date="new Date()"
+						:date="new Date(video.uploadDate ? video.uploadDate : 0)"
 						:watchedCount="video.watchedCount"
 						:duration="new Duration(0, video.duration ?? 0)"
 						:style="{ '--view': view }"

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,30 +1,99 @@
 <script setup lang="ts">
 	useHead({ title: t.search });
 	const router = useRouter(), route = useRoute();
-	const querySearch = route.query.q ?? "";
+	const querySearch = computed(() => route.query.query ?? "");
 
 	const view = ref<ViewType>("grid");
 	const displayPageCount = ref(6);
-	const videos = ref<Videos200Response>();
+	const videos = ref<SearchVideoByKeywordResponseDto | ThumbVideoResponseDto>();
 	const searchModes = ["keyword", "tag", "user", "advanced_search"] as const;
-	const searchMode = ref<typeof searchModes[number]>("tag");
+	const querySearchMode = route.query.mode as typeof searchModes[number] ?? "tag";
+	const searchMode = ref<typeof searchModes[number]>(querySearchMode);
 	const searchModesSorted = computed(() => searchModes.toSorted((a, b) =>
 		a === searchMode.value ? -1 : b === searchMode.value ? 1 : 0));
-	// 注意：请更新你的 Node.js 版本为 20 及以上才能支持该函数，否则会报错。
+	// 注意：请更新你的 Node.js 版本为 20 及以上才能支持该函数，否则会报错。 // 02: 确实！
 
 	const data = reactive({
 		selectedTab: "Home",
-		search: querySearch,
+		search: querySearch.value,
 		sort: ref<SortModel>(["upload_date", "descending"]),
 		page: 1,
 		pages: 99,
 	});
 
 	/**
-	watch(() => data.search, search => {
-		router.push({ path: route.path, query: { ...route.query, q: search || undefined } });
-	});
+	 * 通过关键字搜索视频，并赋值给 video
+	 * @param keyword 关键字
 	 */
+	async function searchVideoByKeyword(keyword: string) {
+		const searchVideoByKeywordRequest: SearchVideoByKeywordRequestDto = { keyword };
+		const videoResult = await api.video.searchVideoByKeyword(searchVideoByKeywordRequest);
+		if (videoResult && videoResult.success) {
+			videos.value = videoResult;
+			data.pages = Math.floor(videoResult.videosCount / 50) + 1;
+		}
+	}
+
+	/**
+	 * 像首页一样获取视频，并赋值给 video
+	 */
+	async function getHomeVideo() {
+		const videoResult = await api.video.getHomePageThumbVideo();
+		if (videoResult && videoResult.success) {
+			videos.value = videoResult;
+			data.pages = Math.floor(videoResult.videosCount / 50) + 1;
+		}
+	}
+
+	/**
+	 * 搜索视频数据
+	 */
+	async function searchVideo() {
+		const query = querySearch.value;
+		if (query)
+			switch (searchMode.value) {
+				case "keyword": {
+					await searchVideoByKeyword(query);
+					break;
+				}
+
+				case "tag": {
+					useToast("暂时不支持这种搜索方法，请使用关键字搜索", "error", 10000); // TODO 使用多语言
+					console.warn("no support search mode: tag");
+					await getHomeVideo();
+					break;
+				}
+
+				case "user": {
+					useToast("暂时不支持这种搜索方法，请使用关键字搜索", "error", 10000); // TODO 使用多语言
+					console.warn("no support search mode: user");
+					await getHomeVideo();
+					break;
+				}
+
+				case "advanced_search": {
+					useToast("暂时不支持这种搜索方法，请使用关键字搜索", "error", 10000); // TODO 使用多语言
+					console.warn("no support search mode: advanced_search");
+					await getHomeVideo();
+					break;
+				}
+
+				default:
+					console.log("do nothing");
+					break;
+			}
+		else
+			await getHomeVideo();
+	}
+
+	await searchVideo();
+
+	watch(() => data.search, search => {
+		router.push({ path: route.path, query: { ...route.query, query: search || undefined } });
+	});
+	watch(() => searchMode.value, searchMode => {
+		router.push({ path: route.path, query: { ...route.query, mode: searchMode || undefined } });
+	});
 </script>
 
 <template>
@@ -37,14 +106,14 @@
 				<div class="videos-grid">
 					<ThumbVideo
 						v-for="video in videos?.videos"
-						:key="video.videoID"
-						:videoId="video.videoID"
-						:uploader="video.authorName ?? ''"
-						:uploaderId="video.authorID"
-						:image="video.thumbnailLoc"
+						:key="video.videoId"
+						:videoId="video.videoId"
+						:uploader="video.uploader ?? ''"
+						:uploaderId="video.uploaderId"
+						:image="video.image"
 						:date="new Date()"
-						:watchedCount="video.views"
-						:duration="new Duration(0, video.videoDuration ?? 0)"
+						:watchedCount="video.watchedCount"
+						:duration="new Duration(0, video.duration ?? 0)"
 						:style="{ '--view': view }"
 					>{{ video.title }}</ThumbVideo>
 				</div>
@@ -52,7 +121,7 @@
 
 			<div class="right">
 				<div class="toolbox-card search">
-					<TextBox v-model="data.search" :placeholder="t.search" icon="search" />
+					<TextBox v-model="data.search" :placeholder="t.search" icon="search" @keyup.enter="searchVideo" />
 					<div class="tags">
 						<TransitionGroup>
 							<Tag

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -114,7 +114,7 @@
 						:uploader="video.uploader ?? ''"
 						:uploaderId="video.uploaderId"
 						:image="video.image"
-						:date="new Date(video.uploadDate ? video.uploadDate : 0)"
+						:date="new Date(video.uploadDate || 0)"
 						:watchedCount="video.watchedCount"
 						:duration="new Duration(0, video.duration ?? 0)"
 						:style="{ '--view': view }"

--- a/types/backend.d.ts
+++ b/types/backend.d.ts
@@ -10,5 +10,5 @@ declare global {
 	export type { CancelVideoCommentDownvoteRequestDto, CancelVideoCommentUpvoteRequestDto, EmitVideoCommentDownvoteRequestDto, EmitVideoCommentRequestDto, EmitVideoCommentUpvoteRequestDto, GetVideoCommentByKvidRequestDto, GetVideoCommentByKvidResponseDto, VideoCommentResult } from "api/Comment/VideoCommentControllerDto";
 	export type { EmitDanmakuRequestDto, GetDanmakuByKvidRequestDto } from "api/Danmaku/DanmakuControllerDto";
 	export type { GetUserInfoByUidRequestDto, GetUserInfoByUidResponseDto, UserExistsCheckRequestDto, UserLabelSchema, UserLoginRequestDto, UserRegistrationRequestDto } from "api/User/UserControllerDto";
-	export type { GetVideoByKvidRequestDto, GetVideoByKvidResponseDto, GetVideoByUidRequestDto, GetVideoByUidResponseDto, ThumbVideoResponseDto } from "api/Video/VideoControllerDto";
+	export type { GetVideoByKvidRequestDto, GetVideoByKvidResponseDto, GetVideoByUidRequestDto, GetVideoByUidResponseDto, SearchVideoByKeywordRequestDto, SearchVideoByKeywordResponseDto, ThumbVideoResponseDto } from "api/Video/VideoControllerDto";
 }


### PR DESCRIPTION
① 实现基础的搜索功能（关键字搜索），其他类型的搜索还未实现，使用其他类型的搜索会出现提示并显示全部视频
② 搜索功能改为在输入框内按下回车键触发，实时输入触发太"昂贵"了
③ "URL 中没有搜索关键字"或"在输入框为空时按下回车“时会获取全部视频
④ 搜索功能也是服务端渲染
⑤ 现在 ”搜索模式“ 和 ”搜索关键字“ 都会临时存储在 URL 中，这样就可以直接通过分享 URL 共享搜索结果 
⑥ 其他 QoL 改进

注：搜索引擎未经优化调教，只使用默认的分词法，搜索结果不是最优表现。