### PR TITLE
:construction: :recycle: :boom: [重大变更] 将存放 CSS 模板等数据的标签由 <html> 改为 .root-node, SSR 时正确渲染用户自定样式

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -81,13 +81,6 @@
 		],
 	});
 
-	watch(() => appSettings.sharpAppearanceMode, enabled => {
-		setClassEnabled(document.documentElement, "sharp", enabled);
-	});
-	watch(() => appSettings.flatAppearanceMode, enabled => {
-		setClassEnabled(document.documentElement, "flat", enabled);
-	});
-
 	const layout = useDynamicLayout();
 
 	// Service Worker
@@ -105,15 +98,7 @@
 </script>
 
 <template>
-	<!-- <NuxtLayout :name="layout">
-		<NuxtPage />
-	</NuxtLayout>
-	<Fragment id="teleports">
-		<Toasts />
-		<Tooltips />
-	</Fragment> -->
-
-	<div style="font-size: 50px;">
+	<div class="root-node" :class="{ sharp: appSettings.sharpAppearanceMode, flat: appSettings.flatAppearanceMode }">
 		<NuxtLayout :name="layout">
 			<NuxtPage />
 		</NuxtLayout>

--- a/app.vue
+++ b/app.vue
@@ -105,11 +105,21 @@
 </script>
 
 <template>
-	<NuxtLayout :name="layout">
+	<!-- <NuxtLayout :name="layout">
 		<NuxtPage />
 	</NuxtLayout>
 	<Fragment id="teleports">
 		<Toasts />
 		<Tooltips />
-	</Fragment>
+	</Fragment> -->
+
+	<div style="font-size: 50px;">
+		<NuxtLayout :name="layout">
+			<NuxtPage />
+		</NuxtLayout>
+		<Fragment id="teleports">
+			<Toasts />
+			<Tooltips />
+		</Fragment>
+	</div>
 </template>

--- a/assets/styles/elements/kbd.scss
+++ b/assets/styles/elements/kbd.scss
@@ -17,7 +17,7 @@ kbd {
 	background-color: c(gray-5);
 	border-radius: 4px;
 	
-	 .root-node.dark & {
+	.root-node.dark & {
 		@include set-box-shadow(gray-10, gray-5);
 		background-color: c(gray-20);
 	}
@@ -28,7 +28,7 @@ kbd {
 		translate: 0 3.2px;
 		background-color: c(gray-20);
 		
-		 .root-node.dark & {
+		.root-node.dark & {
 			@include set-box-shadow(gray-5, gray-5, true);
 			color: c(gray-40);
 			background-color: c(gray-10);

--- a/assets/styles/elements/kbd.scss
+++ b/assets/styles/elements/kbd.scss
@@ -17,7 +17,7 @@ kbd {
 	background-color: c(gray-5);
 	border-radius: 4px;
 	
-	html.dark & {
+	 .root-node.dark & {
 		@include set-box-shadow(gray-10, gray-5);
 		background-color: c(gray-20);
 	}
@@ -28,7 +28,7 @@ kbd {
 		translate: 0 3.2px;
 		background-color: c(gray-20);
 		
-		html.dark & {
+		 .root-node.dark & {
 			@include set-box-shadow(gray-5, gray-5, true);
 			color: c(gray-40);
 			background-color: c(gray-10);

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -232,7 +232,7 @@ label {
 }
 
 // 扁平样式
- .root-node.flat {
+.root-node.flat {
 	@include enhanced-selector {
 		box-shadow: none !important;
 	}

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -225,14 +225,14 @@ label {
 }
 
 // 直角样式
-html.sharp {
+.root-node.sharp {
 	@include enhanced-selector {
 		border-radius: 0 !important;
 	}
 }
 
 // 扁平样式
-html.flat {
+ .root-node.flat {
 	@include enhanced-selector {
 		box-shadow: none !important;
 	}

--- a/components/Accordion/AccordionItem.vue
+++ b/components/Accordion/AccordionItem.vue
@@ -116,7 +116,7 @@
 			color: c(accent);
 			background-color: c(accent-10);
 
-			 .root-node.dark & {
+			.root-node.dark & {
 				color: c(icon-color);
 			}
 

--- a/components/Accordion/AccordionItem.vue
+++ b/components/Accordion/AccordionItem.vue
@@ -116,7 +116,7 @@
 			color: c(accent);
 			background-color: c(accent-10);
 
-			html.dark & {
+			 .root-node.dark & {
 				color: c(icon-color);
 			}
 

--- a/components/Button.vue
+++ b/components/Button.vue
@@ -107,7 +107,7 @@
 			background-color: c(accent-disabled) !important;
 			box-shadow: none !important;
 
-			html.dark & :is(.caption, .icon) {
+			 .root-node.dark & :is(.caption, .icon) {
 				opacity: 0.4;
 			}
 		}

--- a/components/Button.vue
+++ b/components/Button.vue
@@ -107,7 +107,7 @@
 			background-color: c(accent-disabled) !important;
 			box-shadow: none !important;
 
-			 .root-node.dark & :is(.caption, .icon) {
+			.root-node.dark & :is(.caption, .icon) {
 				opacity: 0.4;
 			}
 		}

--- a/components/CapsuleSlider.vue
+++ b/components/CapsuleSlider.vue
@@ -151,7 +151,7 @@
 		pointer-events: none;
 		font-variant-numeric: tabular-nums;
 
-		 .root-node.dark & {
+		.root-node.dark & {
 			color: white;
 		}
 	}

--- a/components/CapsuleSlider.vue
+++ b/components/CapsuleSlider.vue
@@ -151,7 +151,7 @@
 		pointer-events: none;
 		font-variant-numeric: tabular-nums;
 
-		html.dark & {
+		 .root-node.dark & {
 			color: white;
 		}
 	}

--- a/components/Login/LoginWindow.vue
+++ b/components/Login/LoginWindow.vue
@@ -54,6 +54,7 @@
 				if (loginResponse.success && loginResponse.uid) {
 					open.value = false;
 					selfUserInfoStore.isLogined = true;
+					api.user.getUserSettings();
 					useEvent("user:login", true);
 				} else
 					useToast(t.toast.login_failed, "error");

--- a/components/ToggleSwitch.vue
+++ b/components/ToggleSwitch.vue
@@ -189,7 +189,7 @@
 				@include control-ball-shadow-off-disabled;
 				background-color: c(white);
 
-				html.dark & {
+				 .root-node.dark & {
 					background-color: c(gray-40);
 				}
 			}

--- a/components/ToggleSwitch.vue
+++ b/components/ToggleSwitch.vue
@@ -189,7 +189,7 @@
 				@include control-ball-shadow-off-disabled;
 				background-color: c(white);
 
-				 .root-node.dark & {
+				.root-node.dark & {
 					background-color: c(gray-40);
 				}
 			}

--- a/composables/api/User/UserController.ts
+++ b/composables/api/User/UserController.ts
@@ -124,7 +124,7 @@ export const uploadUserAvatar = async (avatarBlobData: Blob, signedUrl: string):
 };
 
 // TODO // WARN 实验性：在服务端或客户端获取用户设置信息用以正确渲染页面，施工中
-export const getUserSettings = async (getUserSettingsRequest: GetUserSettingsRequestDto): Promise<GetUserSettingsResponseDto> => {
+export const getUserSettings = async (getUserSettingsRequest?: GetUserSettingsRequestDto): Promise<GetUserSettingsResponseDto> => {
 	// TODO: use { credentials: "include" } to allow save/read cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
 	const userSettings = await POST(`${USER_API_URI}/settings`, getUserSettingsRequest, { credentials: "include" }) as GetUserSettingsResponseDto;
 	if (userSettings.success) {

--- a/middleware/cookie-baker.global.ts
+++ b/middleware/cookie-baker.global.ts
@@ -14,12 +14,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
 			const cookieUid = useCookie(uidCookieKey, { sameSite: true });
 			const cookieToken = useCookie(tokenCookieKey, { sameSite: true });
-			const cookieShowCssDoodle = useCookie(showCssDoodleCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
-			const cookieSharpAppearanceMode = useCookie(sharpAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
-			const cookieFlatAppearanceMode = useCookie(flatAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
-			const cookieColoredSideBar = useCookie(coloredSideBarCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
+			const cookieShowCssDoodle = useCookie(showCssDoodleCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+			const cookieSharpAppearanceMode = useCookie(sharpAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+			const cookieFlatAppearanceMode = useCookie(flatAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+			const cookieColoredSideBar = useCookie(coloredSideBarCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
 			
-			if (cookieUid !== null && cookieUid !== undefined && cookieToken) {
+			if (cookieUid.value !== null && cookieUid.value !== undefined && cookieUid.value !== "" && cookieToken.value) {
 				const userAuthToken: GetSelfUserInfoRequestDto | GetUserSettingsRequestDto = {
 					uid: cookieUid.value ? parseInt(cookieUid.value, 10) : -1,
 					token: cookieToken.value || "",
@@ -41,10 +41,13 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 		} else {
 			// TODO 客户端渲染
 			
-			const cookieShowCssDoodle = useCookie(showCssDoodleCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
-			const cookieSharpAppearanceMode = useCookie(sharpAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
-			const cookieFlatAppearanceMode = useCookie(flatAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
-			const cookieColoredSideBar = useCookie(coloredSideBarCookieKey, { expires: new Date("9999/9/9"), sameSite: true });
+			const cookieShowCssDoodle = useCookie(showCssDoodleCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+			const cookieSharpAppearanceMode = useCookie(sharpAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+			const cookieFlatAppearanceMode = useCookie(flatAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+			const cookieColoredSideBar = useCookie(coloredSideBarCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false });
+
+			// console.log("cookieShowCssDoodle", cookieShowCssDoodle, cookieShowCssDoodle.value, typeof cookieShowCssDoodle.value);
+			// console.log("cookieSharpAppearanceMode", cookieSharpAppearanceMode, cookieSharpAppearanceMode.value, typeof cookieSharpAppearanceMode.value);
 			
 			appSettingsStore.showCssDoodle = typeof cookieShowCssDoodle.value === "boolean" ? cookieShowCssDoodle.value : cookieShowCssDoodle.value === "true";
 			appSettingsStore.sharpAppearanceMode = typeof cookieSharpAppearanceMode.value === "boolean" ? cookieSharpAppearanceMode.value : cookieSharpAppearanceMode.value === "true";
@@ -52,7 +55,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 			appSettingsStore.coloredSideBar = typeof cookieColoredSideBar.value === "boolean" ? cookieColoredSideBar.value : cookieColoredSideBar.value === "true";
 		}
 	} catch (error) {
-		console.error("ERROR", "烘焙网络曲奇☆时发生了意料外的错误：", error);
+		console.error("ERROR", "在烘焙 网络曲奇☆ 时发生了意料外的错误：", error);
 		if (from.path !== "/")
 			navigateTo("/");
 	}

--- a/modules/unsupported-browsers/601.html
+++ b/modules/unsupported-browsers/601.html
@@ -73,15 +73,15 @@
 			user-select: none;
 		}
 
-		 .root-node.zh-Hant-TW body {
+		.root-node.zh-Hant-TW body {
 			font-family: "Segoe UI", "Microsoft JhengHei", "Microsoft YaHei", Tahoma, Geneva, Verdana, Arial, SimHei, sans-serif;
 		}
 
-		 .root-node.ja body {
+		.root-node.ja body {
 			font-family: "Yu Gothic UI", "Meiryo UI", "MS UI Gothic", "Segoe UI", Tahoma, Geneva, Verdana, Arial, SimHei, sans-serif;
 		}
 
-		 .root-node.ko body {
+		.root-node.ko body {
 			font-family: "Segoe UI", "Malgun Gothic", Dotum, Tahoma, Geneva, Verdana, Arial, SimHei, sans-serif;
 		}
 
@@ -135,30 +135,30 @@
 			font-size: 14px;
 		}
 
-		 .root-node.en .main-card h1,
-		 .root-node.vi .main-card h1,
-		 .root-node.id .main-card h1 {
+		.root-node.en .main-card h1,
+		.root-node.vi .main-card h1,
+		.root-node.id .main-card h1 {
 			line-height: 45px;
 		}
 
-		 .root-node.en .main-card p,
-		 .root-node.vi .main-card p,
-		 .root-node.id .main-card p {
+		.root-node.en .main-card p,
+		.root-node.vi .main-card p,
+		.root-node.id .main-card p {
 			top: 145px;
 			text-align: left;
 		}
 
-		 .root-node.en .main-card .right,
-		 .root-node.ja .main-card .right,
-		 .root-node.vi .main-card .right,
-		 .root-node.id .main-card .right {
+		.root-node.en .main-card .right,
+		.root-node.ja .main-card .right,
+		.root-node.vi .main-card .right,
+		.root-node.id .main-card .right {
 			width: 500px;
 		}
 
-		 .root-node.en .browsers-title,
-		 .root-node.ja .browsers-title,
-		 .root-node.vi .browsers-title,
-		 .root-node.id .browsers-title {
+		.root-node.en .browsers-title,
+		.root-node.ja .browsers-title,
+		.root-node.vi .browsers-title,
+		.root-node.id .browsers-title {
 			margin-right: 50px;
 		}
 
@@ -284,13 +284,13 @@
 			display: none;
 		}
 
-		 .root-node.zh-Hans-CN .text.zh-Hans-CN,
-		 .root-node.zh-Hant-TW .text.zh-Hant-TW,
-		 .root-node.en .text.en,
-		 .root-node.ja .text.ja,
-		 .root-node.ko .text.ko,
-		 .root-node.vi .text.vi,
-		 .root-node.id .text.id {
+		.root-node.zh-Hans-CN .text.zh-Hans-CN,
+		.root-node.zh-Hant-TW .text.zh-Hant-TW,
+		.root-node.en .text.en,
+		.root-node.ja .text.ja,
+		.root-node.ko .text.ko,
+		.root-node.vi .text.vi,
+		.root-node.id .text.id {
 			display: block;
 		}
 	</style>

--- a/modules/unsupported-browsers/601.html
+++ b/modules/unsupported-browsers/601.html
@@ -73,15 +73,15 @@
 			user-select: none;
 		}
 
-		html.zh-Hant-TW body {
+		 .root-node.zh-Hant-TW body {
 			font-family: "Segoe UI", "Microsoft JhengHei", "Microsoft YaHei", Tahoma, Geneva, Verdana, Arial, SimHei, sans-serif;
 		}
 
-		html.ja body {
+		 .root-node.ja body {
 			font-family: "Yu Gothic UI", "Meiryo UI", "MS UI Gothic", "Segoe UI", Tahoma, Geneva, Verdana, Arial, SimHei, sans-serif;
 		}
 
-		html.ko body {
+		 .root-node.ko body {
 			font-family: "Segoe UI", "Malgun Gothic", Dotum, Tahoma, Geneva, Verdana, Arial, SimHei, sans-serif;
 		}
 
@@ -135,30 +135,30 @@
 			font-size: 14px;
 		}
 
-		html.en .main-card h1,
-		html.vi .main-card h1,
-		html.id .main-card h1 {
+		 .root-node.en .main-card h1,
+		 .root-node.vi .main-card h1,
+		 .root-node.id .main-card h1 {
 			line-height: 45px;
 		}
 
-		html.en .main-card p,
-		html.vi .main-card p,
-		html.id .main-card p {
+		 .root-node.en .main-card p,
+		 .root-node.vi .main-card p,
+		 .root-node.id .main-card p {
 			top: 145px;
 			text-align: left;
 		}
 
-		html.en .main-card .right,
-		html.ja .main-card .right,
-		html.vi .main-card .right,
-		html.id .main-card .right {
+		 .root-node.en .main-card .right,
+		 .root-node.ja .main-card .right,
+		 .root-node.vi .main-card .right,
+		 .root-node.id .main-card .right {
 			width: 500px;
 		}
 
-		html.en .browsers-title,
-		html.ja .browsers-title,
-		html.vi .browsers-title,
-		html.id .browsers-title {
+		 .root-node.en .browsers-title,
+		 .root-node.ja .browsers-title,
+		 .root-node.vi .browsers-title,
+		 .root-node.id .browsers-title {
 			margin-right: 50px;
 		}
 
@@ -284,13 +284,13 @@
 			display: none;
 		}
 
-		html.zh-Hans-CN .text.zh-Hans-CN,
-		html.zh-Hant-TW .text.zh-Hant-TW,
-		html.en .text.en,
-		html.ja .text.ja,
-		html.ko .text.ko,
-		html.vi .text.vi,
-		html.id .text.id {
+		 .root-node.zh-Hans-CN .text.zh-Hans-CN,
+		 .root-node.zh-Hant-TW .text.zh-Hant-TW,
+		 .root-node.en .text.en,
+		 .root-node.ja .text.ja,
+		 .root-node.ko .text.ko,
+		 .root-node.vi .text.vi,
+		 .root-node.id .text.id {
 			display: block;
 		}
 	</style>

--- a/pages/settings/appearance.vue
+++ b/pages/settings/appearance.vue
@@ -23,6 +23,8 @@
 		const updateOrCreateUserSettingsRequest: UpdateOrCreateUserSettingsRequestDto = {
 			coloredSideBar: useAppSettingsStore().coloredSideBar,
 		};
+		const coloredSideBarCookieKey = "colored-side-bar";
+		useCookie(coloredSideBarCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false }).value = `${useAppSettingsStore().coloredSideBar}`;
 		api.user.updateUserSettings(updateOrCreateUserSettingsRequest);
 	}
 	watch(() => useAppSettingsStore().coloredSideBar, updateColoredSideBarSetting);
@@ -160,7 +162,7 @@
 				background-color: c(accent);
 				mix-blend-mode: color;
 
-				html.dark & {
+				 .root-node.dark & {
 					mix-blend-mode: hue;
 				}
 			}
@@ -169,7 +171,7 @@
 				background-color: white;
 				opacity: 0.7;
 
-				html.dark & {
+				 .root-node.dark & {
 					background-color: black;
 				}
 			}

--- a/pages/settings/appearance.vue
+++ b/pages/settings/appearance.vue
@@ -162,7 +162,7 @@
 				background-color: c(accent);
 				mix-blend-mode: color;
 
-				 .root-node.dark & {
+				.root-node.dark & {
 					mix-blend-mode: hue;
 				}
 			}
@@ -171,7 +171,7 @@
 				background-color: white;
 				opacity: 0.7;
 
-				 .root-node.dark & {
+				.root-node.dark & {
 					background-color: black;
 				}
 			}

--- a/pages/settings/experimental.vue
+++ b/pages/settings/experimental.vue
@@ -6,6 +6,8 @@
 		const updateOrCreateUserSettingsRequest: UpdateOrCreateUserSettingsRequestDto = {
 			showCssDoodle: useAppSettingsStore().showCssDoodle,
 		};
+		const showCssDoodleCookieKey = "show-css-doodle";
+		useCookie(showCssDoodleCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false }).value = `${useAppSettingsStore().showCssDoodle}`;
 		api.user.updateUserSettings(updateOrCreateUserSettingsRequest);
 	}
 	watch(() => useAppSettingsStore().showCssDoodle, updateShowCssDoodleUserSetting);
@@ -17,6 +19,8 @@
 		const updateOrCreateUserSettingsRequest: UpdateOrCreateUserSettingsRequestDto = {
 			sharpAppearanceMode: useAppSettingsStore().sharpAppearanceMode,
 		};
+		const sharpAppearanceModeCookieKey = "sharp-appearance-mode";
+		useCookie(sharpAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false }).value = `${useAppSettingsStore().sharpAppearanceMode}`;
 		api.user.updateUserSettings(updateOrCreateUserSettingsRequest);
 	}
 	watch(() => useAppSettingsStore().sharpAppearanceMode, updateSharpAppearanceModeUserSetting);
@@ -28,6 +32,8 @@
 		const updateOrCreateUserSettingsRequest: UpdateOrCreateUserSettingsRequestDto = {
 			flatAppearanceMode: useAppSettingsStore().flatAppearanceMode,
 		};
+		const flatAppearanceModeCookieKey = "flat-appearance-mode";
+		useCookie(flatAppearanceModeCookieKey, { expires: new Date("9999/9/9"), sameSite: true, httpOnly: false }).value = `${useAppSettingsStore().flatAppearanceMode}`;
 		api.user.updateUserSettings(updateOrCreateUserSettingsRequest);
 	}
 	watch(() => useAppSettingsStore().flatAppearanceMode, updateFlatAppearanceModeUserSetting);


### PR DESCRIPTION
:construction: :recycle: :boom: [重大变更]

1. 将存放 CSS 模板等数据的标签由 `<html></html>` 元素改为 app.vue 中的 `<div class="root-node"></div>`
2. 不再
```监听（watch） appSettings 状态库（pinia store）并使用 setClassEnabled(dom, ...) 方法来修改根节点的 class```
而是
```使用 Vue 模板语法动态改变 <div class="root-node"></div> 的 class```
使其在首屏 SSR 时能返回正确的文档，无需等待水和或 mounted
4. SSR 时正确渲染用户自定样式设置 [目前支持：彩色侧栏、动态背景、直角模式、扁平模式]
5. [副作用] 因为在 SSR 时已经请求用户数据，所以已登录用户在首屏渲染时，头像不再闪烁（由默认图标变为用户自定义头像）

注意：这不是一个合并到 develop 分支的 PR，仅供审阅重大变更事项。对于不优雅的代码，将会在正式合并至 develop 分支前在 [refactoring-2024012201-User_v2-cfdxkk](https://github.com/KIRAKIRA-DOUGA/KIRAKIRA-Cerasus/tree/refactoring-2024012201-User_v2-cfdxkk) 分支修正。