### PR TITLE
:sparkles: 用户删除自己的评论 / 管理员删除任意一条评论

### DIFF
--- a/components/Creation/CreationComments/CreationComments.vue
+++ b/components/Creation/CreationComments/CreationComments.vue
@@ -44,6 +44,8 @@
 				:commentId="comment._id"
 				:videoId
 				:index="comment.commentIndex"
+				:uid="comment.uid"
+				:commentRoute="comment.commentRoute"
 				:username="comment.userInfo?.username"
 				:avatar="comment.userInfo?.avatar"
 				:date="new Date(comment.editDateTime)"
@@ -68,16 +70,16 @@
 	.toolbar {
 		display: flex;
 		flex-wrap: wrap;
-		align-items: center;
 		justify-content: space-between;
+		align-items: center;
 		margin-top: 16px;
 
 		> * {
 			display: flex;
 			flex-wrap: wrap;
 			gap: 16px;
-			align-items: center;
 			justify-content: flex-end;
+			align-items: center;
 		}
 
 		.soft-button {

--- a/components/Creation/CreationComments/CreationCommentsItem.vue
+++ b/components/Creation/CreationComments/CreationCommentsItem.vue
@@ -13,7 +13,9 @@
 		/** 评论发布日期。 */
 		date?: Date;
 		/** 用户 UID。 */
-		uid?: number;
+		uid: number;
+		/** 评论的路由 */
+		commentRoute: string;
 	}>(), {
 		avatar: undefined,
 		username: "匿名",
@@ -38,6 +40,8 @@
 	const voteLock = ref(false);
 
 	const userSelfInfoStore = useSelfUserInfoStore();
+	const isSelfComment = computed(() => props.uid === userSelfInfoStore.uid); // 这条评论是否是自己发送的
+	const isAdmin = computed(() => userSelfInfoStore.role === "admin"); // 这条评论是否是自己发送的
 
 	/**
 	 * 点击加分、减分按钮事件。
@@ -175,14 +179,43 @@
 	}
 
 	/**
-	 * // TODO: 删除评论。
-	 * @param commentId - 评论 ID。
+	 * 删除自己的评论
+	 * @param commentRoute - 评论的路由
+	 * @param videoId - KVID 视频 ID
 	 */
-	async function deleteComment(commentId: number | undefined) {
-		if (!commentId) return;
-		const api = useApi();
-		await api.deleteComment(commentId);
-		// TODO: trigger reload in parent
+	async function deleteSelfComment(commentRoute?: string, videoId?: number) {
+		if (!commentRoute || !videoId) return;
+		const deleteSelfVideoCommentRequest: DeleteSelfVideoCommentRequestDto = {
+			videoId,
+			commentRoute,
+		};
+		const deleteVideoResult = await api.videoComment.deleteSelfVideoComment(deleteSelfVideoCommentRequest);
+		if (deleteVideoResult.success) {
+			useToast("删除评论成功！", "success", 5000); // TODO: 使用多语言
+			useEvent("videoComment:deleteVideoComment", commentRoute);
+		} else
+			useToast("删除评论失败！", "error", 5000); // TODO: 使用多语言
+			// TODO: 性能问题
+	}
+
+	/**
+	 * 管理员删除评论
+	 * @param commentRoute - 评论的路由
+	 * @param videoId - KVID 视频 ID
+	 */
+	async function adminDeleteVideoComment(commentRoute?: string, videoId?: number) {
+		if (!commentRoute || !videoId) return;
+		const adminDeleteVideoCommentRequest: AdminDeleteVideoCommentRequestDto = {
+			videoId,
+			commentRoute,
+		};
+		const deleteVideoResult = await api.videoComment.adminDeleteVideoComment(adminDeleteVideoCommentRequest);
+		if (deleteVideoResult.success) {
+			useToast("删除评论成功！", "success", 5000); // TODO: 使用多语言
+			useEvent("videoComment:deleteVideoComment", commentRoute);
+		} else
+			useToast("删除评论失败！", "error", 5000); // TODO: 使用多语言
+			// TODO: 性能问题
 	}
 </script>
 
@@ -219,7 +252,9 @@
 					<SoftButton v-tooltip:bottom="t.reply" icon="reply" />
 					<SoftButton v-tooltip:bottom="t.more" icon="more_vert" @click="e => menu = [e, 'y']" />
 					<Menu v-model="menu">
-						<MenuItem icon="delete" @click="deleteComment(index)">{{ t.delete }}</MenuItem>
+						<MenuItem v-if="isSelfComment" icon="delete" @click="deleteSelfComment(commentRoute, videoId)">{{ t.delete }}</MenuItem>
+						<!-- TODO: 使用多语言 -->
+						<MenuItem v-if="isAdmin" icon="delete" @click="adminDeleteVideoComment(commentRoute, videoId)">{{ t.delete }}（管理员）</MenuItem>
 						<MenuItem :icon="unpinnedCaption" @click="pinned = !pinned">{{ t[unpinnedCaption] }}</MenuItem>
 						<hr />
 						<MenuItem icon="flag">{{ t.report }}</MenuItem>
@@ -257,8 +292,8 @@
 		}
 
 		.username {
-			font-weight: bold;
 			font-size: 16px;
+			font-weight: bold;
 		}
 	}
 

--- a/composables/api/Comment/VideoCommentController.ts
+++ b/composables/api/Comment/VideoCommentController.ts
@@ -1,6 +1,6 @@
 import { DELETE, GET, POST } from "../Common";
 import getCorrectUri from "../Common/getCorrectUri";
-import type { CancelVideoCommentDownvoteRequestDto, CancelVideoCommentUpvoteRequestDto, EmitVideoCommentDownvoteRequestDto, EmitVideoCommentDownvoteResponseDto, EmitVideoCommentRequestDto, EmitVideoCommentResponseDto, EmitVideoCommentUpvoteRequestDto, EmitVideoCommentUpvoteResponseDto, GetVideoCommentByKvidRequestDto, GetVideoCommentByKvidResponseDto } from "./VideoCommentControllerDto";
+import type { CancelVideoCommentDownvoteRequestDto, CancelVideoCommentUpvoteRequestDto, DeleteSelfVideoCommentRequestDto, DeleteSelfVideoCommentResponseDto, AdminDeleteVideoCommentRequestDto, AdminDeleteVideoCommentResponseDto, EmitVideoCommentDownvoteRequestDto, EmitVideoCommentDownvoteResponseDto, EmitVideoCommentRequestDto, EmitVideoCommentResponseDto, EmitVideoCommentUpvoteRequestDto, EmitVideoCommentUpvoteResponseDto, GetVideoCommentByKvidRequestDto, GetVideoCommentByKvidResponseDto } from "./VideoCommentControllerDto";
 
 const BACK_END_URL = getCorrectUri();
 const VIDEO_COMMENT_API_URL = `${BACK_END_URL}/video/comment`;
@@ -63,4 +63,24 @@ export const cancelVideoCommentUpvote = async (cancelVideoCommentUpvoteRequest: 
 export const cancelVideoCommentDownvote = async (cancelVideoCommentDownvoteRequest: CancelVideoCommentDownvoteRequestDto): Promise<EmitVideoCommentDownvoteResponseDto> => {
 	// TODO: use { credentials: "include" } to allow save/read cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
 	return await DELETE(`${VIDEO_COMMENT_API_URL}/downvote/cancel`, cancelVideoCommentDownvoteRequest, { credentials: "include" }) as EmitVideoCommentDownvoteResponseDto;
+};
+
+/**
+ * 删除一条自己发布的视频评论
+ * @param deleteSelfVideoCommentRequest 删除一条自己发布的视频评论的请求载荷
+ * @returns 删除一条自己发布的视频评论的请求响应
+ */
+export const deleteSelfVideoComment = async (deleteSelfVideoCommentRequest: DeleteSelfVideoCommentRequestDto): Promise<DeleteSelfVideoCommentResponseDto> => {
+	// TODO: use { credentials: "include" } to allow save/read cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
+	return await DELETE(`${VIDEO_COMMENT_API_URL}/deleteSelfComment`, deleteSelfVideoCommentRequest, { credentials: "include" }) as DeleteSelfVideoCommentResponseDto;
+};
+
+/**
+ * 管理员删除一条视频评论
+ * @param dadminDeleteVideoCommentRequest 管理员删除一条视频评论的请求载荷
+ * @returns 管理员删除一条视频评论的请求响应
+ */
+export const adminDeleteVideoComment = async (dadminDeleteVideoCommentRequest: AdminDeleteVideoCommentRequestDto): Promise<AdminDeleteVideoCommentResponseDto> => {
+	// TODO: use { credentials: "include" } to allow save/read cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
+	return await DELETE(`${VIDEO_COMMENT_API_URL}/adminDeleteComment`, dadminDeleteVideoCommentRequest, { credentials: "include" }) as AdminDeleteVideoCommentResponseDto;
 };

--- a/composables/api/Comment/VideoCommentControllerDto.d.ts
+++ b/composables/api/Comment/VideoCommentControllerDto.d.ts
@@ -96,7 +96,7 @@ export type GetVideoCommentByKvidRequestDto = {
 };
 
 type VideoCommentIdDto = {
-	/** 评论的路由 */ /** 如：1.2.3（视频的第一个评论的第二个回复的第三个回复） */
+	/** 评论的路由 */ /** 如：1.2.3（第一号视频的第二个评论的第三个子回复） */
 	commentRoute: string;
 	/** 评论 ID */
 	upvoteCount: string;
@@ -126,7 +126,7 @@ type CommentSenderUserInfo = {
 export type VideoCommentResult = {
 	/** MongoDB 生成的唯一 ID */
 	_id: string;
-	/** 评论的路由 */ /** 如：1.2.3（视频的第一个评论的第二个回复的第三个回复） */
+	/** 评论的路由 */ /** 如：1.2.3（第一号视频的第二个评论的第三个子回复） */
 	commentRoute: string;
 	/** KVID 视频 ID */
 	videoId: number;
@@ -244,6 +244,46 @@ export type CancelVideoCommentDownvoteRequestDto = {
 * 取消视频评论点踩的请求的响应结果
 */
 export type CancelVideoCommentDownvoteResponseDto = {
+	/** 是否请求成功 */
+	success: boolean;
+	/** 附加的文本消息 */
+	message?: string;
+};
+
+/**
+ * 删除一个自己的视频评论的请求载荷
+ */
+export type DeleteSelfVideoCommentRequestDto = {
+	/** 评论的路由 */
+	commentRoute: string;
+	/** KVID 视频 ID */
+	videoId: number;
+};
+
+/**
+ * 删除一个自己的视频评论的请求响应
+ */
+export type DeleteSelfVideoCommentResponseDto = {
+	/** 是否请求成功 */
+	success: boolean;
+	/** 附加的文本消息 */
+	message?: string;
+};
+
+/**
+ * 管理员删除一个视频评论的请求载荷
+ */
+export type AdminDeleteVideoCommentRequestDto = {
+	/** 评论的路由 */
+	commentRoute: string;
+	/** KVID 视频 ID */
+	videoId: number;
+};
+
+/**
+ * 管理员删除一个视频评论的请求响应
+ */
+export type AdminDeleteVideoCommentResponseDto = {
 	/** 是否请求成功 */
 	success: boolean;
 	/** 附加的文本消息 */

--- a/composables/event-bus.ts
+++ b/composables/event-bus.ts
@@ -16,6 +16,7 @@ type ApplicationEvents = {
 	"component:hideAllContextualToolbar": void;
 	"user:login": boolean;
 	"videoComment:emitVideoComment": VideoCommentResult;
+	"videoComment:deleteVideoComment": string;
 };
 
 const emitter = mitt<ApplicationEvents>();

--- a/pages/video/kv[kvid].vue
+++ b/pages/video/kv[kvid].vue
@@ -84,8 +84,19 @@
 
 	onMounted(fetchVideoCommentData);
 
+	/**
+	 * 发送评论，将发送的评论添加到评论列表中
+	 */
 	useListen("videoComment:emitVideoComment", videoComment => {
 		comments.value.push(videoComment);
+	});
+
+	/**
+	 * 删除评论，根据被删除的评论路由来过滤评论列表
+	 * // TODO: 性能改进
+	 */
+	useListen("videoComment:deleteVideoComment", commentRoute => {
+		comments.value = comments.value.filter(comment => comment.commentRoute !== commentRoute);
 	});
 
 	useHead({

--- a/types/backend.d.ts
+++ b/types/backend.d.ts
@@ -10,7 +10,7 @@ import * as _videoTag from "api/VideoTag/VideoTagControllerDto";
  */
 declare global {
 	// VideoCommentControllerDto
-	export type { GetUserBrowsingHistoryWithFilterRequestDto, GetUserBrowsingHistoryWithFilterResponseDto } from "api/BrowsingHistory/BrowsingHistoryControllerDto";
+	export type { AdminDeleteVideoCommentRequestDto, DeleteSelfVideoCommentRequestDto, GetUserBrowsingHistoryWithFilterRequestDto, GetUserBrowsingHistoryWithFilterResponseDto } from "api/BrowsingHistory/BrowsingHistoryControllerDto";
 	// VideoCommentControllerDto
 	export type { CancelVideoCommentDownvoteRequestDto, CancelVideoCommentUpvoteRequestDto, EmitVideoCommentDownvoteRequestDto, EmitVideoCommentRequestDto, EmitVideoCommentUpvoteRequestDto, GetVideoCommentByKvidRequestDto, GetVideoCommentByKvidResponseDto, VideoCommentResult } from "api/Comment/VideoCommentControllerDto";
 	// DanmakuControllerDto


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/67392d99-5ca1-4143-94e5-bc9dfffc258e)
### :sparkles: 用户删除自己的评论 / 管理员删除任意一条评论

✔ 后端已更新至最新版本
@otomad @Aira-Sakuranomiya 

#### 测试焦点
* 用户可以删除自己评论
   * 如果不是自己的评论，看不到删除按钮
* 管理员可以删除任何评论
   * 普通用户看不到管理员专用的删除按钮


#### 已知问题
* 删除评论后要等待很久才会成功（过滤数据时的性能问题）
* 删除评论按钮不支持加载动画
* 点击按钮后 “菜单” 立即关闭了，而不是等待真正删除成功