### PR TITLE
✨ 管理员可以看见用户新上传，还未标为审核通过的视频

### DIFF
--- a/composables/api/Video/VideoController.ts
+++ b/composables/api/Video/VideoController.ts
@@ -1,7 +1,7 @@
 import getCorrectUri from "api/Common/getCorrectUri";
 import * as tus from "tus-js-client";
 import { GET, POST, DELETE, uploadFile2CloudflareImages } from "../Common";
-import type { DeleteVideoRequestDto, DeleteVideoResponseDto, GetVideoByKvidRequestDto, GetVideoByKvidResponseDto, GetVideoByUidRequestDto, GetVideoByUidResponseDto, GetVideoCoverUploadSignedUrlResponseDto, SearchVideoByVideoTagIdRequestDto, SearchVideoByVideoTagIdResponseDto, ThumbVideoResponseDto, UploadVideoRequestDto, UploadVideoResponseDto } from "./VideoControllerDto";
+import type { ApprovePendingReviewVideoRequestDto, ApprovePendingReviewVideoResponseDto, DeleteVideoRequestDto, DeleteVideoResponseDto, GetVideoByKvidRequestDto, GetVideoByKvidResponseDto, GetVideoByUidRequestDto, GetVideoByUidResponseDto, GetVideoCoverUploadSignedUrlResponseDto, PendingReviewVideoResponseDto, SearchVideoByVideoTagIdRequestDto, SearchVideoByVideoTagIdResponseDto, ThumbVideoResponseDto, UploadVideoRequestDto, UploadVideoResponseDto } from "./VideoControllerDto";
 
 const BACK_END_URL = getCorrectUri();
 const VIDEO_API_URL = `${BACK_END_URL}/video`;
@@ -238,4 +238,25 @@ export async function commitVideo(uploadVideoRequest: UploadVideoRequestDto): Pr
  */
 export async function deleteVideo(deleteVideoRequest: DeleteVideoRequestDto): Promise<DeleteVideoResponseDto> {
 	return await DELETE(`${VIDEO_API_URL}/delete`, deleteVideoRequest, { credentials: "include" }) as DeleteVideoResponseDto;
+}
+
+/**
+ * 获取待审核视频列表
+ * @param headerCookie  从客户端发起 SSR 请求时传递的 Header 中的 Cookie 部分，在 SSR 时将其转交给后端 API
+ * @returns 获取待审核视频列表的请求响应
+ */
+export const getPendingReviewVideo = async (headerCookie: { cookie?: string | undefined }): Promise<PendingReviewVideoResponseDto> => {
+	// NOTE: use { headers: headerCookie } to passing client-side cookies to backend API when SSR.
+	// TODO: use { credentials: "include" } to allow save/read cookies from cross-origin domains. Maybe we should remove it before deployment to production env.
+	const { data: result } = await useFetch(`${VIDEO_API_URL}/pending`, { headers: headerCookie, credentials: "include" });
+	return result.value as PendingReviewVideoResponseDto;
+};
+
+/**
+ * 通过一个待审核视频
+ * @param approvePendingReviewVideoRequest 通过一个待审核视频的请求载荷
+ * @returns 通过一个待审核视频的请求响应
+ */
+export async function approvePendingReviewVideo(approvePendingReviewVideoRequest: ApprovePendingReviewVideoRequestDto): Promise<ApprovePendingReviewVideoResponseDto> {
+	return await POST(`${VIDEO_API_URL}/pending/approved`, approvePendingReviewVideoRequest, { credentials: "include" }) as ApprovePendingReviewVideoResponseDto;
 }

--- a/composables/api/Video/VideoControllerDto.d.ts
+++ b/composables/api/Video/VideoControllerDto.d.ts
@@ -242,3 +242,26 @@ export type DeleteVideoResponseDto = {
 	/** 附加的文本消息 */
 	message?: string;
 };
+
+/**
+ * 等待被审核的视频列表
+ */
+export type PendingReviewVideoResponseDto = {} & ThumbVideoResponseDto;
+
+/**
+ * 通过一个待审核视频的请求载荷
+ */
+export type ApprovePendingReviewVideoRequestDto = {
+	/** 视频 ID (KVID) */
+	videoId: number;
+};
+
+/**
+ * 通过一个待审核视频的请求响应
+ */
+export type ApprovePendingReviewVideoResponseDto = {
+	/** 请求是否成功，成功返回 true，否则返回 false */
+	success: boolean;
+	/** 附加的文本消息 */
+	message?: string;
+};

--- a/pages/settings/content.vue
+++ b/pages/settings/content.vue
@@ -8,6 +8,17 @@
 	const deleteVideoInfo = ref<GetVideoByKvidResponseDto["video"]>();
 	const isDeletingVideo = ref(false);
 
+	const resultTimestamp = ref(0);
+	const pendingReviewVideos = ref<PendingReviewVideoResponseDto>();
+
+	const deletePendingVideoId = ref(-1);
+	const deletePendingVideoInfo = ref<GetVideoByKvidResponseDto["video"]>();
+	const showDeletePendingVideoAlert = ref(false);
+	const isOpeningDeletePendingVideoAlert = ref(false);
+	const isDeletingPendingVideo = ref(false);
+
+	const isApprovingPendingVideo = ref(false);
+
 	/**
 	 * 开启删除视频的警告框
 	 */
@@ -50,19 +61,98 @@
 			useToast("视频已删除", "success");
 		} else
 			useToast("无法删除目标视频，请检查视频 ID 是否正确", "error", 5000);
+		deleteVideoInfo.value = undefined;
 		isDeletingVideo.value = false;
 	}
+
+	/**
+	 * 开启删除待审核视频的警告框
+	 * @param videoId 视频 ID
+	 */
+	async function openDeletePendingVideoAlert(videoId: number) {
+		if (videoId < 0) {
+			useToast("视频 ID 不正确", "error", 5000);
+			return;
+		}
+		deletePendingVideoId.value = videoId;
+		isOpeningDeletePendingVideoAlert.value = true;
+		const getVideoByKvidRequest: GetVideoByKvidRequestDto = {
+			videoId,
+		};
+		const deletePendingVideoInfoResult = await api.video.getVideoByKvid(getVideoByKvidRequest);
+		if (deletePendingVideoInfoResult.success && deletePendingVideoInfoResult.video) {
+			deletePendingVideoInfo.value = deletePendingVideoInfoResult.video;
+			showDeletePendingVideoAlert.value = true;
+		} else
+			useToast("无法获取目标视频，请检查视频 ID 是否正确", "error", 5000);
+		isOpeningDeletePendingVideoAlert.value = false;
+	}
+
+	/**
+	 * 删除一个待审核视频
+	 */
+	async function deletePendingVideo() {
+		if (deletePendingVideoId.value < 0) {
+			useToast("未正确输入视频 ID", "error", 5000);
+			return;
+		}
+		isDeletingPendingVideo.value = true;
+		const deletePendingVideoRequest: DeleteVideoRequestDto = {
+			videoId: deletePendingVideoId.value,
+		};
+		const deletePendingVideoResult = await api.video.deleteVideo(deletePendingVideoRequest);
+		if (deletePendingVideoResult.success) {
+			await getPendingReviewVideo();
+			showDeletePendingVideoAlert.value = false;
+			deletePendingVideoId.value = -1;
+			useToast("待审核视频已删除", "success");
+		} else
+			useToast("无法删除待审核视频，请检查视频 ID 是否正确", "error", 5000);
+		deletePendingVideoInfo.value = undefined;
+		isDeletingPendingVideo.value = false;
+	}
+
+	/**
+	 * 根据 videoId 通过一个待审核视频
+	 * @param videoId 视频 ID
+	 */
+	async function approvePendingReviewVideo(videoId: number) {
+		if (videoId < 0) {
+			useToast("无法通过视频，视频 ID 不正确", "error", 5000);
+			return;
+		}
+		isApprovingPendingVideo.value = true;
+		const approvePendingReviewVideoRequest: ApprovePendingReviewVideoRequestDto = {
+			videoId,
+		};
+		const approvePendingReviewVideoResult = await api.video.approvePendingReviewVideo(approvePendingReviewVideoRequest);
+		if (approvePendingReviewVideoResult.success) {
+			await getPendingReviewVideo();
+			useToast("已通过审核", "success");
+		} else
+			useToast("无法通过审核，请重试", "success");
+		isApprovingPendingVideo.value = false;
+	}
+
+	/**
+	 * 获取待审核视频列表
+	 */
+	async function getPendingReviewVideo() {
+		const headerCookie = useRequestHeaders(["cookie"]);
+		pendingReviewVideos.value = await api.video.getPendingReviewVideo(headerCookie);
+	}
+
+	await getPendingReviewVideo();
 
 	definePageMeta(
 		{
 			middleware: [
-				(to, from) => {
-					// WARN: 此处需要重新创建 Store
-					const selfUserInfoStore = useSelfUserInfoStore();
+				(to: unknown) => {
+					const selfUserInfoStore = useSelfUserInfoStore(); // WARN: 此处需要重新创建 Store
 					if (selfUserInfoStore.role !== "admin")
 						return navigateTo("/settings/appearance");
 
-					if (to.path !== "/settings/content")
+					if (to && typeof to === "object" && "path" in to && to.path !== "/settings/content")
 						return navigateTo("/settings/content");
 				},
 			],
@@ -87,12 +177,42 @@
 			>{{ deleteVideoInfo.title }}</ThumbVideo>
 		</div>
 		<template #footer-left>
-			<Button @click="deleteVideo" :loading="isDeletingVideo" :disabled="isDeletingVideo">确认删除</Button>
+			<Button @click="deleteVideo" :loading="isDeletingPendingVideo || isDeletingVideo" :disabled="!isAdmin || isDeletingPendingVideo || isDeletingVideo">确认删除</Button>
 		</template>
 		<template #footer-right>
 			<Button @click="showDeleteVideoAlert = false" class="secondary">取消</Button>
 		</template>
 	</Alert>
+
+	<Alert v-model="showDeletePendingVideoAlert" static>
+		<h4>确定要删除这个待审核视频吗？</h4>
+		<div class="delete-thumb-video">
+			<ThumbVideo
+				v-if="deletePendingVideoInfo"
+				:videoId="deletePendingVideoInfo.videoId"
+				:uploader="deletePendingVideoInfo.uploader ?? ''"
+				:uploaderId="deletePendingVideoInfo.uploaderId"
+				:image="deletePendingVideoInfo.image"
+				:date="new Date(deletePendingVideoInfo.uploadDate || 0)"
+				:watchedCount="deletePendingVideoInfo.watchedCount"
+				:duration="new Duration(0, deletePendingVideoInfo.duration ?? 0)"
+				:blank="true"
+			>{{ deletePendingVideoInfo.title }}</ThumbVideo>
+		</div>
+		<template #footer-left>
+			<Button
+				@click="deletePendingVideo"
+				:loading="isDeletingPendingVideo || isDeletingVideo"
+				:disabled="!isAdmin || isDeletingPendingVideo || isDeletingVideo"
+			>
+				确认删除
+			</Button>
+		</template>
+		<template #footer-right>
+			<Button @click="showDeletePendingVideoAlert = false" class="secondary">取消</Button>
+		</template>
+	</Alert>
+
 	<div class="delete-video">
 		<div class="input">
 			<!-- TODO: 使用多语言 -->
@@ -106,8 +226,55 @@
 			<!-- TODO: 使用多语言 -->
 			<span>输入要删除的视频的 KV 号，例如 kv1 只需输入数字 1 即可。</span>
 		</div>
-		<Button @click="openDeleteVideoAlert" :disabled="!isAdmin || isOpeningDeleteVideoAlert" :loading="isOpeningDeleteVideoAlert">删除视频</Button>
+		<Button
+			@click="openDeleteVideoAlert"
+			:disabled="!isAdmin || isOpeningDeleteVideoAlert || isOpeningDeletePendingVideoAlert || isApprovingPendingVideo"
+			:loading="isOpeningDeleteVideoAlert || isOpeningDeletePendingVideoAlert || isApprovingPendingVideo"
+		>
+			删除视频
+		</Button>
 	</div>
+
+	<!-- TODO: 使用多语言 -->
+	<Subheader icon="block">新上传的视频</Subheader>
+	<h4>新上传待审核的视频</h4>
+	<ThumbGrid :key="resultTimestamp">
+		<div
+			class="pending-videos"
+			v-for="video in pendingReviewVideos?.videos"
+			:key="video.videoId"
+		>
+			<ThumbVideo
+				:videoId="video.videoId"
+				:uploader="video.uploader ?? ''"
+				:uploaderId="video.uploaderId"
+				:image="video.image"
+				:date="new Date(video.uploadDate || 0)"
+				:watchedCount="video.watchedCount"
+				:duration="new Duration(0, video.duration ?? 0)"
+			>
+				{{ video.title }}
+			</ThumbVideo>
+			<div class="button-group">
+				<Button
+					class="secondary"
+					@click="() => approvePendingReviewVideo(video.videoId)"
+					:disabled="!isAdmin || isOpeningDeleteVideoAlert || isOpeningDeletePendingVideoAlert || isApprovingPendingVideo"
+					:loading="isOpeningDeleteVideoAlert || isOpeningDeletePendingVideoAlert || isApprovingPendingVideo"
+				>
+					通过
+				</Button>
+				<Button
+					class="secondary"
+					@click="() => openDeletePendingVideoAlert(video.videoId)"
+					:disabled="!isAdmin || isOpeningDeleteVideoAlert || isOpeningDeletePendingVideoAlert || isApprovingPendingVideo"
+					:loading="isOpeningDeleteVideoAlert || isOpeningDeletePendingVideoAlert || isApprovingPendingVideo"
+				>
+					删除
+				</Button>
+			</div>
+		</div>
+	</ThumbGrid>
 </template>
 
 <style scoped lang="scss">
@@ -144,6 +311,12 @@
 
 		.thumb-video {
 			width: 250px;
+		}
+	}
+
+	.pending-videos {
+		.button-group {
+			margin-bottom: 30px;
 		}
 	}
 </style>

--- a/pages/settings/user.vue
+++ b/pages/settings/user.vue
@@ -84,13 +84,13 @@
 	definePageMeta(
 		{
 			middleware: [
-				(to, from) => {
+				(to: unknown) => {
 					// WARN: 此处需要重新创建 Store
 					const selfUserInfoStore = useSelfUserInfoStore();
 					if (selfUserInfoStore.role !== "admin")
 						return navigateTo("/settings/appearance");
 
-					if (to.path !== "/settings/user")
+					if (to && typeof to === "object" && "path" in to && to.path !== "/settings/user")
 						return navigateTo("/settings/user");
 				},
 			],
@@ -142,6 +142,7 @@
 		<Button @click="openBlockUserAlert" :disabled="!isAdmin || isOpeningBlockUserAlert" :loading="isOpeningBlockUserAlert">封禁用户</Button>
 	</div>
 
+	<!-- TODO: 使用多语言 -->
 	<Subheader icon="block">已封禁用户</Subheader>
 	<section>
 		<SettingsChipItem

--- a/types/backend.d.ts
+++ b/types/backend.d.ts
@@ -18,7 +18,7 @@ declare global {
 	// UserControllerDto
 	export type { ReactivateUserByUIDRequestDto, GetBlockedUserResponseDto, BlockUserByUIDRequestDto, CheckUsernameRequestDto, UpdateUserPasswordRequestDto, RequestSendChangePasswordVerificationCodeRequestDto, UpdateUserEmailRequestDto, RequestSendChangeEmailVerificationCodeRequestDto, GetMyInvitationCodeResponseDto, CheckInvitationCodeRequestDto, RequestSendVerificationCodeRequestDto, GetSelfUserInfoRequestDto, GetUserInfoByUidRequestDto, GetUserInfoByUidResponseDto, GetUserSettingsRequestDto, GetUserSettingsResponseDto, UpdateOrCreateUserInfoRequestDto, UpdateOrCreateUserSettingsRequestDto, UserExistsCheckRequestDto, UserLabelSchema, UserLoginRequestDto, UserRegistrationRequestDto } from "api/User/UserControllerDto";
 	// VideoControllerDto
-	export type { DeleteVideoRequestDto, GetVideoByKvidRequestDto, GetVideoByKvidResponseDto, GetVideoByUidRequestDto, GetVideoByUidResponseDto, SearchVideoByKeywordRequestDto, SearchVideoByKeywordResponseDto, SearchVideoByVideoTagIdRequestDto, ThumbVideoResponseDto, UploadVideoRequestDto } from "api/Video/VideoControllerDto";
+	export type { ApprovePendingReviewVideoRequestDto, PendingReviewVideoResponseDto, DeleteVideoRequestDto, GetVideoByKvidRequestDto, GetVideoByKvidResponseDto, GetVideoByUidRequestDto, GetVideoByUidResponseDto, SearchVideoByKeywordRequestDto, SearchVideoByKeywordResponseDto, SearchVideoByVideoTagIdRequestDto, ThumbVideoResponseDto, UploadVideoRequestDto } from "api/Video/VideoControllerDto";
 	// VideoTagControllerDto
 	export type { CreateVideoTagRequestDto, GetVideoTagByTagIdRequestDto, VideoTag } from "api/VideoTag/VideoTagControllerDto";
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/758bcf2d-02c0-4e9d-8ff2-0221855689d1)

### :sparkles: 管理员可以看见用户新上传，还未标为审核通过的视频

✔ 后端已更新至最新版本
⚠ 未经测试（没有可用视频）
@otomad @Aira-Sakuranomiya 

#### 测试焦点
* 管理员可以看见用户新上传，还未标为审核通过的视频
   * 应当出现 “通过” 和 “删除” 按钮
* 删除视频
   * 正确弹出警告框，点击确认后最终删除视频
   * 删除视频后警告框正确关闭
   * 已删除的视频不应该在任何位置显示
* 通过视频
   * 通过的视频不应该再显示在审核和主页
* 多个按钮的 `loading` 和 `disabled` 状态管理是否正常
* 点击删除一个视频后，再次点击删除另一个视频，被删除的视频是新视频还是刚刚已经删除的旧视频
* 点击通过一个视频后，再次点击通过另一个视频，被通过的视频是新视频还是刚刚已经通过的旧视频
