### PR TITLE
feat: new scrollbar

### DIFF
--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -9,7 +9,6 @@
 	box-sizing: border-box;
 	margin-block: 0;
 	margin-inline: 0;
-	scroll-behavior: smooth;
 	font-family: $simplified-chinese-fonts;
 	// font-feature-settings: "ss02" on, "ss01" on, "liga" on, "rlig" on, "dlig" on, "hlig" on, "onum" on, "kern" on; // 开多了有点过分了。
 	font-feature-settings: "ss03" on; // 圆形的逗号、引号。
@@ -82,7 +81,7 @@ xmp {
 
 html,
 body {
-	scrollbar-gutter: stable; // WARN: Chromium 114 开始，overflow 的 overlay 成了 auto 的别名，因此只能提前占位显示来确保不晃动。目前甚至 Chromium 自己的设置页都在依赖于 overlay，太荒谬了。https://bugs.chromium.org/p/chromium/issues/detail?id=1450927
+	overflow: hidden;
 	font-size: 14px;
 }
 

--- a/components/Flyout/FlyoutKaomoji/FlyoutKaomoji.vue
+++ b/components/Flyout/FlyoutKaomoji/FlyoutKaomoji.vue
@@ -33,9 +33,9 @@
 			</TabBar>
 			<div>
 				<Transition :name="transitionName" mode="out-in">
-					<div :key="selected" class="grid">
+					<ScrollContainer :key="selected">
 						<FlyoutKaomojiButton v-for="i in kaomojiList" :key="i" @click="input(i)">{{ i }}</FlyoutKaomojiButton>
-					</div>
+					</ScrollContainer>
 				</Transition>
 			</div>
 		</Comp>
@@ -60,16 +60,22 @@
 		}
 	}
 
-	.grid {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: 6px;
-		align-content: flex-start;
-		align-items: baseline;
+	.scroll-container {
 		height: $height;
-		padding: 12px $padding-x;
-		padding-top: 0.25rem;
-		overflow-y: auto;
+
+		&:deep(.scroller) {
+			overscroll-behavior: contain;
+
+			> .content {
+				display: grid;
+				grid-template-columns: repeat(3, 1fr);
+				gap: 6px;
+				align-content: flex-start;
+				align-items: baseline;
+				padding: 12px $padding-x;
+				padding-top: 0.25rem;
+			}
+		}
 	}
 
 	// stylelint-disable-next-line order/order

--- a/components/Player/PlayerVideo/PlayerVideoPanel/PlayerVideoPanelDanmaku/PlayerVideoPanelDanmakuList.vue
+++ b/components/Player/PlayerVideo/PlayerVideoPanel/PlayerVideoPanelDanmaku/PlayerVideoPanelDanmakuList.vue
@@ -140,7 +140,6 @@
 
 	:comp {
 		flex-grow: 1;
-		overflow-x: overlay;
 		color: c(icon-color);
 
 		> .scroll-container {

--- a/components/Player/PlayerVideo/PlayerVideoPanel/PlayerVideoPanelDanmaku/PlayerVideoPanelDanmakuList.vue
+++ b/components/Player/PlayerVideo/PlayerVideoPanel/PlayerVideoPanelDanmaku/PlayerVideoPanelDanmakuList.vue
@@ -91,32 +91,34 @@
 <template>
 	<Comp>
 		<ClientOnly>
-			<table class="lite">
-				<thead>
-					<th v-for="(header, column, j) in headers" :key="header" v-ripple :width="colWidths[j]" @click="() => sort(j)">
-						<span>{{ header }}</span>
-						<Icon
-							name="chevron_up"
-							:class="sortBy[0] === column && {
-								ascending: sortBy[1] === 'ascending',
-								descending: sortBy[1] === 'descending',
-							}"
-						/>
-					</th>
-					<div class="shadow">
-						<th v-for="(header, _column, j) in headers" :key="header" :width="colWidths[j]">
-							<div class="grip" :data-index="j" @pointerdown="onGripDown"></div>
+			<ScrollContainer>
+				<table class="lite">
+					<thead>
+						<th v-for="(header, column, j) in headers" :key="header" v-ripple :width="colWidths[j]" @click="() => sort(j)">
+							<span>{{ header }}</span>
+							<Icon
+								name="chevron_up"
+								:class="sortBy[0] === column && {
+									ascending: sortBy[1] === 'ascending',
+									descending: sortBy[1] === 'descending',
+								}"
+							/>
 						</th>
-					</div>
-				</thead>
-				<tbody>
-					<RecycleScroller v-slot="{ item }" class="scroller" :itemSize="28" keyField="key" :items="danmakuList">
-						<tr :key="item.key" v-ripple @contextmenu.prevent="e => { currentDanmaku = item.item; danmakuItemMenu = e; }">
-							<td v-for="(value, key, j) in item.item" :key="key" :width="colWidths[j]">{{ handleTableDataCellText(value) }}</td>
-						</tr>
-					</RecycleScroller>
-				</tbody>
-			</table>
+						<div class="shadow">
+							<th v-for="(header, _column, j) in headers" :key="header" :width="colWidths[j]">
+								<div class="grip" :data-index="j" @pointerdown="onGripDown"></div>
+							</th>
+						</div>
+					</thead>
+					<tbody>
+						<RecycleScroller v-slot="{ item }" class="scroller" :itemSize="28" keyField="key" :items="danmakuList" pageMode>
+							<tr :key="item.key" v-ripple @contextmenu.prevent="e => { currentDanmaku = item.item; danmakuItemMenu = e; }">
+								<td v-for="(value, key, j) in item.item" :key="key" :width="colWidths[j]">{{ handleTableDataCellText(value) }}</td>
+							</tr>
+						</RecycleScroller>
+					</tbody>
+				</table>
+			</ScrollContainer>
 			<template #fallback>
 				<div class="danmaku-placeholder">
 					<ProgressRing />
@@ -140,6 +142,14 @@
 		flex-grow: 1;
 		overflow-x: overlay;
 		color: c(icon-color);
+
+		> .scroll-container {
+			height: 100%;
+
+			&:deep(.scroller) {
+				overscroll-behavior: contain;
+			}
+		}
 
 		table {
 			position: relative;

--- a/components/Player/PlayerVideo/PlayerVideoPanel/PlayerVideoPanelSettings.vue
+++ b/components/Player/PlayerVideo/PlayerVideoPanel/PlayerVideoPanelSettings.vue
@@ -68,48 +68,49 @@
 <template>
 	<div class="wrapper">
 		<Comp>
-			<Transition :name="transitionName" mode="out-in">
-				<div v-if="selectedSettingsTab === 'player' " class="page-player">
-					<ToggleSwitch v-model="settings.autoplay" v-ripple icon="autoplay">{{ t.player.autoplay }}</ToggleSwitch>
-					<p>{{ t.danmaku }}</p>
-					<!-- TODO: 多语言。检查字号缩放功能的可用性并显示缩放数值。 -->
-					<SettingsSlider
-						v-model="settings.danmaku.fontSizeScale"
-						:min="0"
-						:max="2"
-						:defaultValue="1"
-						icon="font_size"
-					>字号缩放</SettingsSlider>
-					<SettingsSlider
-						v-model="settings.danmaku.opacity"
-						:min="0"
-						:max="1"
-						:defaultValue="1"
-						icon="opacity"
-					>{{ t.opacity }}</SettingsSlider>
-					<p>{{ t.player.control_bar }}</p>
-					<ToggleSwitch v-model="settings.controller.showFrameByFrame" v-ripple icon="slow_forward">{{ t.player.control_bar.show_frame_by_frame }}</ToggleSwitch>
-				</div>
+			<ScrollContainer overflowX="clip">
+				<Transition :name="transitionName" mode="out-in">
+					<div v-if="selectedSettingsTab === 'player' " class="page-player">
+						<ToggleSwitch v-model="settings.autoplay" v-ripple icon="autoplay">{{ t.player.autoplay }}</ToggleSwitch>
+						<p>{{ t.danmaku }}</p>
+						<!-- TODO: 多语言。检查字号缩放功能的可用性并显示缩放数值。 -->
+						<SettingsSlider
+							v-model="settings.danmaku.fontSizeScale"
+							:min="0"
+							:max="2"
+							:defaultValue="1"
+							icon="font_size"
+						>字号缩放</SettingsSlider>
+						<SettingsSlider
+							v-model="settings.danmaku.opacity"
+							:min="0"
+							:max="1"
+							:defaultValue="1"
+							icon="opacity"
+						>{{ t.opacity }}</SettingsSlider>
+						<p>{{ t.player.control_bar }}</p>
+						<ToggleSwitch v-model="settings.controller.showFrameByFrame" v-ripple icon="slow_forward">{{ t.player.control_bar.show_frame_by_frame }}</ToggleSwitch>
+					</div>
 
-				<div v-else-if="selectedSettingsTab === 'filters'">
-					<div class="grid">
-						<CheckCard v-for="([filter, style], key) in filters" :key="key" v-model="filterBooleanProxy[key]">
-							{{ filter }}
-							<template #image>
-								<NuxtImg
-									:style
-									:provider="environment.cloudflareImageProvider"
-									:src="thumbnail"
-									:alt="`preview-${filter}`"
-									:draggable="false"
-									format="avif"
-									width="200"
-									height="200"
-									:placeholder="[20, 20, 100, 2]"
-								/>
-							</template>
-						</CheckCard>
-					<!-- <CheckCard v-model="settings.filter.horizontalFlip">
+					<div v-else-if="selectedSettingsTab === 'filters'">
+						<div class="grid">
+							<CheckCard v-for="([filter, style], key) in filters" :key="key" v-model="filterBooleanProxy[key]">
+								{{ filter }}
+								<template #image>
+									<NuxtImg
+										:style
+										:provider="environment.cloudflareImageProvider"
+										:src="thumbnail"
+										:alt="`preview-${filter}`"
+										:draggable="false"
+										format="avif"
+										width="200"
+										height="200"
+										:placeholder="[20, 20, 100, 2]"
+									/>
+								</template>
+							</CheckCard>
+							<!-- <CheckCard v-model="settings.filter.horizontalFlip">
 					水平翻转
 					<template #image><NuxtImg :src="thumbnail" alt="preview" /></template>
 				</CheckCard>
@@ -117,19 +118,20 @@
 					垂直翻转
 					<template #image><NuxtImg :src="thumbnail" alt="preview" /></template>
 				</CheckCard> -->
+						</div>
 					</div>
-				</div>
 
-				<div v-else-if="selectedSettingsTab === 'block-words'">
-					<ToggleSwitch v-model="blockWordsToggle" v-ripple icon="visibility_off">开启屏蔽</ToggleSwitch>
+					<div v-else-if="selectedSettingsTab === 'block-words'">
+						<ToggleSwitch v-model="blockWordsToggle" v-ripple icon="visibility_off">开启屏蔽</ToggleSwitch>
 
-					<TabBar v-model="blockWordsSelectedTab">
-						<TabItem id="block-keywords">屏蔽文本</TabItem>
-						<TabItem id="block-regex">屏蔽正则</TabItem>
-						<TabItem id="block-users">屏蔽用户</TabItem>
-					</TabBar>
-				</div>
-			</Transition>
+						<TabBar v-model="blockWordsSelectedTab">
+							<TabItem id="block-keywords">屏蔽文本</TabItem>
+							<TabItem id="block-regex">屏蔽正则</TabItem>
+							<TabItem id="block-users">屏蔽用户</TabItem>
+						</TabBar>
+					</div>
+				</Transition>
+			</ScrollContainer>
 		</Comp>
 		<ShadingIcon icon="settings" position="right bottom" rotating :elastic="playing" large />
 	</div>
@@ -145,7 +147,14 @@
 		flex-grow: 1;
 		height: 100%;
 		contain: strict;
-		overflow: clip auto;
+
+		> .scroll-container {
+			height: 100%;
+
+			&:deep(.scroller) {
+				overscroll-behavior: contain;
+			}
+		}
 	}
 
 	.wrapper {

--- a/components/ScrollContainer.vue
+++ b/components/ScrollContainer.vue
@@ -1,0 +1,462 @@
+<docs>
+	# 滚动容器
+
+	自制滚动条，支持垂直和水平方向，支持控制滚动条的边距。
+	将组件套在外层，内部的内容将会自动判断是否需要滚动条。
+</docs>
+
+<script setup lang="ts">
+	const props = withDefaults(defineProps<{
+		overflowX?: "visible" | "hidden" | "clip" | "scroll" | "auto";
+		overflowY?: "visible" | "hidden" | "clip" | "scroll" | "auto";
+	}>(), {
+		overflowX: "auto",
+		overflowY: "auto",
+	});
+
+	const scrollerEl = ref<HTMLDivElement>();
+	const contentEl = ref<HTMLDivElement>();
+
+	const pointerType = ref("touch");
+
+	const scrollableVertical = ref(false);
+	const scrollableHorizontal = ref(false);
+
+	const draggingVertical = ref(false);
+	const draggingHorizontal = ref(false);
+
+	const trackVertical = ref<HTMLDivElement>();
+	const thumbVertical = ref<HTMLDivElement>();
+	const thumbVerticalHeight = ref(0); // 百分比
+	const thumbVerticalTop = ref(0); // 百分比
+
+	const trackHorizontal = ref<HTMLDivElement>();
+	const thumbHorizontal = ref<HTMLDivElement>();
+	const thumbHorizontalWidth = ref(0); // 百分比
+	const thumbHorizontalLeft = ref(0); // 百分比
+
+	const thumbVerticalScaleX = ref(1);
+	const thumbHorizontalScaleY = ref(1);
+
+	const showVertical = ref(false);
+	const showHorizontal = ref(false);
+	const hideVerticalTimeout = ref<Timeout>();
+	const hideHorizontalTimeout = ref<Timeout>();
+	/** 指定在鼠标移出区域多久后自动隐藏。 */
+	const WAITING = 1000;
+
+	/**
+	 * 更新滚动条位置。
+	 */
+	function updateScrollPercentage() {
+		if (!scrollerEl.value) return;
+
+		/** 判断是否需要显示滚动条 */
+		scrollableVertical.value = (props.overflowY === "scroll" || props.overflowY === "auto") && scrollerEl.value.scrollHeight > scrollerEl.value.clientHeight;
+		scrollableHorizontal.value = (props.overflowX === "scroll" || props.overflowX === "auto") && scrollerEl.value.scrollWidth > scrollerEl.value.clientWidth;
+
+		/** 垂直滚动条 */
+		const scrollTop = scrollerEl.value.scrollTop;
+		const maxScrollTop = scrollerEl.value.scrollHeight - scrollerEl.value.clientHeight;
+		let overscroll = 0;
+		if (scrollTop < 0)
+			overscroll = -scrollTop;
+		else if (scrollTop > maxScrollTop)
+			overscroll = scrollTop - maxScrollTop;
+
+		/** overscroll 时缩放 thumb 宽度 */
+		const baseThumbHeight = scrollerEl.value.clientHeight / scrollerEl.value.scrollHeight * 100;
+		const squeezedThumbHeight = Math.max(baseThumbHeight - overscroll * 100 / scrollerEl.value.scrollHeight, 10);
+		const verticalScale = 1 - Math.min(overscroll / scrollerEl.value.clientHeight, 0.8); // 最多缩小 80%
+		thumbVerticalScaleX.value = verticalScale;
+
+		/** 超出边界时固定在边缘 */
+		let newThumbTopPercentage = 0;
+		if (scrollTop < 0)
+			newThumbTopPercentage = 0;
+		else if (scrollTop > maxScrollTop)
+			newThumbTopPercentage = 100 - squeezedThumbHeight;
+		else
+			newThumbTopPercentage = scrollerEl.value.scrollTop / scrollerEl.value.scrollHeight * 100;
+
+		thumbVerticalHeight.value = squeezedThumbHeight;
+		thumbVerticalTop.value = newThumbTopPercentage;
+
+		/** 水平滚动条 */
+		const scrollLeft = scrollerEl.value.scrollLeft;
+		const maxScrollLeft = scrollerEl.value.scrollWidth - scrollerEl.value.clientWidth;
+		let overscrollX = 0;
+		if (scrollLeft < 0)
+			overscrollX = -scrollLeft;
+		else if (scrollLeft > maxScrollLeft)
+			overscrollX = scrollLeft - maxScrollLeft;
+
+		/** overscroll 时缩放 thumb 高度 */
+		const baseThumbWidth = scrollerEl.value.clientWidth / scrollerEl.value.scrollWidth * 100;
+		const squeezedThumbWidth = Math.max(baseThumbWidth - overscrollX * 100 / scrollerEl.value.scrollWidth, 10);
+		const horizontalScale = 1 - Math.min(overscrollX / scrollerEl.value.clientWidth, 0.8); // 最多缩小 80%
+		thumbHorizontalScaleY.value = horizontalScale;
+
+		/** 超出边界时固定在边缘 */
+		let newThumbLeftPercentage = 0;
+		if (scrollLeft < 0)
+			newThumbLeftPercentage = 0;
+		else if (scrollLeft > maxScrollLeft)
+			newThumbLeftPercentage = 100 - squeezedThumbWidth;
+		else
+			newThumbLeftPercentage = scrollerEl.value.scrollLeft / scrollerEl.value.scrollWidth * 100;
+
+		thumbHorizontalWidth.value = squeezedThumbWidth;
+		thumbHorizontalLeft.value = newThumbLeftPercentage;
+	}
+
+	/**
+	 * 准备倒计时隐藏垂直滚动条。
+	 */
+	function readyToHideVertical() {
+		clearTimeout(hideVerticalTimeout.value);
+		hideVerticalTimeout.value = setTimeout(() => {
+			showVertical.value = false;
+		}, WAITING);
+	}
+
+	/**
+	 * 准备倒计时隐藏水平滚动条。
+	 */
+	function readyToHideHorizontal() {
+		clearTimeout(hideHorizontalTimeout.value);
+		hideHorizontalTimeout.value = setTimeout(() => {
+			showHorizontal.value = false;
+		}, WAITING);
+	}
+
+	/**
+	 * 用户滚动或者内容大小改变。
+	 */
+	function onScrollChange() {
+		updateScrollPercentage();
+		showVertical.value = true;
+		readyToHideVertical();
+		showHorizontal.value = true;
+		readyToHideHorizontal();
+	}
+
+	/**
+	 * 按下垂直滚动条时拖动滚动条。
+	 * @param e - 指针事件。
+	 */
+	function onThumbVerticalDown(e: PointerEvent) {
+		draggingVertical.value = true;
+		const thumbRect = thumbVertical.value!.getBoundingClientRect();
+		const startOffsetY = e.clientY - thumbRect.top;
+		clearTimeout(hideVerticalTimeout.value);
+
+		function changeValue(e: PointerEvent) {
+			if (!scrollerEl.value) return;
+			const trackRect = trackVertical.value!.getBoundingClientRect();
+			const thumbHeight = thumbVertical.value!.getBoundingClientRect().height;
+			const scrollHeight = scrollerEl.value.scrollHeight - scrollerEl.value.clientHeight;
+			const scrollPercentage = (e.clientY - trackRect.top - startOffsetY) / (trackRect.height - thumbHeight);
+			scrollerEl.value.scrollTop = scrollHeight * scrollPercentage;
+		}
+
+		function onThumbVerticalUp() {
+			draggingVertical.value = false;
+			readyToHideVertical();
+			document.removeEventListener("pointermove", changeValue);
+			document.removeEventListener("lostpointercapture", onThumbVerticalUp);
+			document.removeEventListener("pointerup", onThumbVerticalUp);
+		}
+
+		document.addEventListener("pointermove", changeValue);
+		document.addEventListener("lostpointercapture", onThumbVerticalUp);
+		document.addEventListener("pointerup", onThumbVerticalUp);
+	}
+
+	/**
+	 * 按下水平滚动条时拖动滚动条。
+	 * @param e - 指针事件。
+	 */
+	function onThumbHorizontalDown(e: PointerEvent) {
+		draggingHorizontal.value = true;
+		const thumbRect = thumbHorizontal.value!.getBoundingClientRect();
+		const startOffsetX = e.clientX - thumbRect.left;
+		clearTimeout(hideHorizontalTimeout.value);
+
+		function changeValue(e: PointerEvent) {
+			if (!scrollerEl.value) return;
+			const trackRect = trackHorizontal.value!.getBoundingClientRect();
+			const thumbWidth = thumbHorizontal.value!.getBoundingClientRect().width;
+			const scrollWidth = scrollerEl.value.scrollWidth - scrollerEl.value.clientWidth;
+			const scrollPercentage = (e.clientX - trackRect.left - startOffsetX) / (trackRect.width - thumbWidth);
+			scrollerEl.value.scrollLeft = scrollWidth * scrollPercentage;
+		}
+
+		function onThumbHorizontalUp() {
+			draggingHorizontal.value = false;
+			readyToHideHorizontal();
+			document.removeEventListener("pointermove", changeValue);
+			document.removeEventListener("lostpointercapture", onThumbHorizontalUp);
+			document.removeEventListener("pointerup", onThumbHorizontalUp);
+		}
+
+		document.addEventListener("pointermove", changeValue);
+		document.addEventListener("lostpointercapture", onThumbHorizontalUp);
+		document.addEventListener("pointerup", onThumbHorizontalUp);
+	}
+
+	/**
+	 * 点击垂直轨道时滚动到对应位置，仅在鼠标操作时生效。
+	 * @param e - 指针事件。
+	 */
+	function onTrackVerticalDown(e: PointerEvent) {
+		if (!scrollerEl.value || !trackVertical.value || !thumbVertical.value || pointerType.value !== "mouse") return;
+
+		const trackRect = trackVertical.value.getBoundingClientRect();
+		const thumbRect = thumbVertical.value.getBoundingClientRect();
+
+		/** 计算点击位置，并以 thumb 中心为基准 */
+		const clickY = e.clientY - trackRect.top - thumbRect.height / 2;
+		/** 限制范围 */
+		const availableHeight = trackRect.height - thumbRect.height;
+		const scrollPercentage = Math.min(1, Math.max(0, clickY / availableHeight));
+
+		const scrollHeight = scrollerEl.value.scrollHeight - scrollerEl.value.clientHeight;
+		scrollerEl.value.scrollTo({ top: scrollHeight * scrollPercentage, behavior: "smooth" });
+	}
+
+	/**
+	 * 点击水平轨道时滚动到对应位置，仅在鼠标操作时生效。
+	 * @param e - 指针事件。
+	 */
+	function onTrackHorizontalDown(e: PointerEvent) {
+		if (!scrollerEl.value || !trackHorizontal.value || !thumbHorizontal.value || pointerType.value !== "mouse") return;
+
+		const trackRect = trackHorizontal.value.getBoundingClientRect();
+		const thumbRect = thumbHorizontal.value.getBoundingClientRect();
+
+		/** 计算点击位置，并以 thumb 中心为基准 */
+		const clickX = e.clientX - trackRect.left - thumbRect.width / 2;
+		/** 限制范围 */
+		const availableWidth = trackRect.width - thumbRect.width;
+		const scrollPercentage = Math.min(1, Math.max(0, clickX / availableWidth));
+
+		const scrollWidth = scrollerEl.value.scrollWidth - scrollerEl.value.clientWidth;
+		scrollerEl.value.scrollTo({ left: scrollWidth * scrollPercentage, behavior: "smooth" });
+	}
+
+	onMounted(() => {
+		if (!isMobile()) pointerType.value = "mouse";
+		useResizeObserver(contentEl, onScrollChange);
+	});
+</script>
+
+<template>
+	<Comp
+		:class="{
+			dragging: draggingVertical || draggingHorizontal,
+			touch: pointerType === 'touch',
+			mouse: pointerType === 'mouse',
+			'scrollable-both': scrollableVertical && scrollableHorizontal,
+		}"
+	>
+		<div
+			ref="scrollerEl"
+			class="scroller"
+			@scroll="onScrollChange"
+			:style="{ overflowX: props.overflowX, overflowY: props.overflowY }"
+		>
+			<div ref="contentEl" class="content">
+				<slot></slot>
+			</div>
+		</div>
+		<div v-show="scrollableVertical" class="bar vertical" :class="{ show: showVertical, dragging: draggingVertical }">
+			<div ref="trackVertical" class="track" @pointerdown="onTrackVerticalDown">
+				<div
+					ref="thumbVertical"
+					class="thumb"
+					:style="{
+						height: `${thumbVerticalHeight}%`,
+						top: `${thumbVerticalTop}%`,
+						transform: `scaleX(${thumbVerticalScaleX})`,
+					}"
+					@pointerdown.stop="onThumbVerticalDown"
+					@contextmenu.stop.prevent
+					@touchstart.stop.prevent
+				>
+					<div class="inner"></div>
+				</div>
+			</div>
+		</div>
+		<div v-show="scrollableHorizontal" class="bar horizontal" :class="{ show: showHorizontal, dragging: draggingHorizontal }">
+			<div ref="trackHorizontal" class="track" @pointerdown="onTrackHorizontalDown">
+				<div
+					ref="thumbHorizontal"
+					class="thumb"
+					:style="{
+						width: `${thumbHorizontalWidth}%`,
+						left: `${thumbHorizontalLeft}%`,
+						transform: `scaleY(${thumbHorizontalScaleY})`,
+					}"
+					@pointerdown.stop="onThumbHorizontalDown"
+					@contextmenu.stop.prevent
+					@touchstart.stop.prevent
+				>
+					<div class="inner"></div>
+				</div>
+			</div>
+		</div>
+	</Comp>
+</template>
+
+<style scoped lang="scss">
+	@layer props {
+		:comp {
+			--padding-top: 0;
+			--padding-bottom: 0;
+			--padding-left: 0;
+			--padding-right: 0;
+		}
+	}
+
+	:comp {
+		position: relative;
+	}
+
+	.scroller {
+		@include square(100%);
+		padding: var(--padding-top) var(--padding-right) var(--padding-bottom) var(--padding-left);
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+			width: 0;
+			height: 0;
+		}
+
+		:comp.dragging &,
+		:comp.dragging & * {
+			cursor: default;
+			pointer-events: none;
+			user-select: none;
+			touch-action: none;
+		}
+	}
+
+	.bar {
+		$touch-size: 9px;
+		$touch-size-dragging: 14px;
+		$mouse-size: 12px;
+		$mouse-size-dragging: 16px;
+		position: absolute;
+		z-index: 29;
+		opacity: 0;
+		cursor: default;
+		user-select: none;
+		touch-action: none;
+
+		&.vertical {
+			top: var(--padding-top);
+			right: var(--padding-right);
+			bottom: var(--padding-bottom);
+
+			:comp.touch & {
+				width: $touch-size;
+
+				&.dragging {
+					width: $touch-size-dragging;
+				}
+			}
+
+			:comp.mouse & {
+				width: $mouse-size;
+
+				&:any-hover,
+				&.dragging {
+					width: $mouse-size-dragging;
+					opacity: 1;
+				}
+			}
+
+			.thumb {
+				width: 100%;
+			}
+		}
+
+		&.horizontal {
+			right: var(--padding-right);
+			bottom: var(--padding-bottom);
+			left: var(--padding-left);
+
+			:comp.scrollable-both & {
+				margin-right: $mouse-size-dragging;
+			}
+
+			:comp.touch & {
+				height: $touch-size;
+
+				&.dragging {
+					height: $touch-size-dragging;
+				}
+			}
+
+			:comp.mouse & {
+				height: $mouse-size;
+
+				&:any-hover,
+				&.dragging {
+					height: $mouse-size-dragging;
+					opacity: 1;
+				}
+			}
+
+			.thumb {
+				height: 100%;
+			}
+		}
+
+		&.vertical,
+		&.horizontal {
+			&:any-hover,
+			&.dragging {
+				:comp.mouse & .track {
+					background-color: c(main-fg, 5%);
+				}
+
+				.thumb .inner {
+					background-color: c(icon-color);
+					backdrop-filter: blur(8px);
+				}
+			}
+		}
+
+		&.show {
+			opacity: 1;
+		}
+	}
+
+	.track {
+		@include oval;
+		@include square(100%);
+		position: relative;
+		transition: background-color 200ms;
+	}
+
+	.thumb {
+		position: absolute;
+		padding: 3px;
+		transition: padding 200ms;
+
+		:comp.mouse & {
+			padding: 4px;
+		}
+
+		.inner {
+			@include oval;
+			width: 100%;
+			height: 100%;
+			background-color: c(icon-color, 60%);
+			backdrop-filter: blur(8px);
+		}
+	}
+</style>

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -151,6 +151,11 @@
 		overflow: clip;
 		background-color: c(main-bg);
 
+		@include mobile {
+			background-color: c(main-bg, 75%);
+			backdrop-filter: blur(16px);
+		}
+
 		:root.colored-sidebar & {
 			@include sidebar-shadow-colored;
 			--color: white;
@@ -419,7 +424,8 @@
 		z-index: 30;
 		padding: $icons-gap 0;
 		overflow: clip;
-		background-color: c(main-bg);
+		background-color: c(main-bg, 75%);
+		backdrop-filter: blur(16px);
 
 		.icons {
 			@include square(100%);

--- a/layouts/responsive.vue
+++ b/layouts/responsive.vue
@@ -5,8 +5,6 @@
 <script setup lang="ts">
 	import background from "assets/styles/css-doodles/background.css-doodle";
 
-	const container = ref<HTMLDivElement>();
-	const containerMain = ref<HTMLElement>();
 	const cssDoodle = refComp();
 	const showCssDoodle = computed(() => useAppSettingsStore().showCssDoodle);
 	const backgroundImageSettingsStore = useAppSettingsStore().backgroundImage;
@@ -43,24 +41,34 @@
 			</div>
 		</ClientOnly>
 		<SideBar />
-		<main ref="container" class="container">
+		<ScrollContainer class="container" :overflowX="isCurrentSettings ? 'hidden' : undefined">
 			<Banner />
-			<div class="router-view" :class="{ 'is-settings': isCurrentSettings }">
+			<div class="router-view">
 				<slot></slot>
 			</div>
-		</main>
+		</ScrollContainer>
 		<div v-if="showDrawer" class="hide-drawer-mask" @click="showDrawer = false"></div>
 	</div>
 </template>
 
 <style scoped lang="scss">
-	.container {
+	.scroll-container {
 		position: relative;
-		padding-left: $sidebar-width;
+		width: 100dvw;
+		height: 100dvh;
 		transition: $fallback-transitions, width 0s, height 0s;
 
+		@include not-mobile {
+			--padding-left: #{$sidebar-width};
+		}
+
+		@include mobile {
+			--padding-top: #{$mobile-toolbar-height};
+			--padding-bottom: #{$mobile-toolbar-height};
+		}
+
 		@layer layout {
-			> .router-view:deep() > .container {
+			> .scroller > .content > .router-view:deep() > .container {
 				padding: 26px $page-padding-x;
 
 				@include tablet {
@@ -69,7 +77,6 @@
 
 				@include mobile {
 					padding: $page-padding-x-mobile;
-					padding-bottom: $page-padding-x-mobile + $mobile-toolbar-height;
 				}
 			}
 		}
@@ -142,11 +149,6 @@
 	}
 
 	@include mobile {
-		.container {
-			padding-top: $mobile-toolbar-height;
-			padding-left: 0;
-		}
-
 		aside,
 		nav {
 			width: 100dvw;
@@ -201,12 +203,5 @@
 		inset: 0;
 		z-index: 99;
 		cursor: pointer;
-	}
-</style>
-
-<style lang="scss">
-	body:has(.router-view.is-settings) {
-		overflow-x: hidden;
-		overscroll-behavior: none;
 	}
 </style>

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
 		"tus-js-client": "^4.1.0",
 		"vue-audio-visual": "^3.0.8",
 		"vue-cropper": "^1.1.4",
+		"vue-router-better-scroller": "^0.0.0",
 		"vue-virtual-scroller": "2.0.0-beta.8"
 	},
 	"pnpm": {

--- a/pages/dev/components.vue
+++ b/pages/dev/components.vue
@@ -281,9 +281,9 @@
 					<UploaderAira :hidden="!isUploaderLovinIt" />
 				</AccordionItem>
 				<AccordionItem title="滚动条测试">
-					<div class="scroll-test">
+					<ScrollContainer class="scroll-test">
 						<div class="scroll-test-item"></div>
-					</div>
+					</ScrollContainer>
 				</AccordionItem>
 				<AccordionItem title="工具提示测试">
 					注意触摸屏设备不会触发。
@@ -398,7 +398,6 @@
 	.scroll-test {
 		width: 100%;
 		height: 500px;
-		overflow: overlay;
 
 		.scroll-test-item {
 			@include square(200%);

--- a/pages/dev/index.vue
+++ b/pages/dev/index.vue
@@ -30,6 +30,7 @@
 		["富文本测试页", "/dev/test-rich-text-editor"],
 		["动态图标测试页", "/dev/test-lottie"],
 		["字体测试页", "/dev/test-font"],
+		["滚动测试页", "/dev/test-scroll"],
 		["滑块测试页", "/dev/test-slider"],
 		["颜色测试页", "/dev/test-color"],
 		["指针类型检测", "/dev/pointer-type"],

--- a/pages/dev/test-scroll.vue
+++ b/pages/dev/test-scroll.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+	<div class="content">
+		<NuxtImg src="/static/images/palettes/blue.png" />
+		<div v-for="i in 100" :key="i" class="item">Item {{ i }}</div>
+		<NuxtImg src="/static/images/palettes/pink.png" />
+	</div>
+</template>
+
+<style scoped lang="scss">
+	img {
+		width: 120%;
+	}
+</style>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -117,7 +117,7 @@
 
 		<nav :class="{ show: showDrawer }">
 			<div class="content">
-				<header class="title content padding-end">
+				<header class="title content">
 					<header class="title nav-header">
 						<h1>{{ t.settings }}</h1>
 						<TextBox v-model="search" type="search" :placeholder="t.settings.search" icon="search" />
@@ -148,7 +148,7 @@
 
 		<div class="card"></div>
 		<main ref="main">
-			<div class="content padding-end">
+			<div class="content">
 				<header class="title page-header" :class="{ colored: cookieColoredSidebar }">
 					<div class="show-drawer-wrapper page-title-icon-wrapper">
 						<SoftButton icon="dehaze" @click="showDrawer = true" />
@@ -213,6 +213,8 @@
 		@include tablet {
 			@include system-card;
 			@include acrylic-background;
+			position: fixed;
+			z-index: 30;
 			transition-duration: $show-drawer-duration;
 
 			&:not(.show) {
@@ -229,15 +231,14 @@
 			flex-direction: column;
 			gap: 10px;
 			max-height: 100dvh;
-			padding: 0 $nav-padding-x;
+			padding: 0 $nav-padding-x $nav-padding-x;
 			overflow: hidden overlay;
 			overscroll-behavior-y: contain;
 			scrollbar-gutter: stable; // WARN: Chromium 114 开始，overflow 的 overlay 成了 auto 的别名，因此只能提前占位显示来确保不晃动。目前甚至 Chromium 自己的设置页都在依赖于 overlay，太荒谬了。https://bugs.chromium.org/p/chromium/issues/detail?id=1450927
 			transition: none;
 
 			@include mobile {
-				max-height: calc(100dvh - $sidebar-width);
-				padding: 0 $mobile-nav-padding-x;
+				padding: 0 $mobile-nav-padding-x $mobile-nav-padding-x;
 			}
 
 			> * {
@@ -312,7 +313,7 @@
 			flex-direction: column;
 			gap: 1rem;
 			max-width: $max-width;
-			padding: 0 $main-padding-x;
+			padding: 0 $main-padding-x $main-padding-x;
 
 			@include mobile {
 				padding: 0 $mobile-padding;
@@ -325,8 +326,8 @@
 					gap: 1rem;
 
 					@include mobile {
-						padding-top: $mobile-toolbar-height + $mobile-padding;
-						padding-bottom: $mobile-toolbar-height + $mobile-padding;
+						padding-top: $mobile-padding;
+						padding-bottom: $mobile-padding;
 					}
 				}
 			}
@@ -422,6 +423,7 @@
 		@include mobile {
 			@include sidebar-shadow;
 			position: fixed;
+			top: 0;
 			align-items: center;
 			width: 100%;
 			height: $mobile-toolbar-height;

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -118,30 +118,32 @@
 		<nav :class="{ show: showDrawer }">
 			<div class="content">
 				<header class="title content">
-					<header class="title nav-header">
-						<h1>{{ t.settings }}</h1>
-						<TextBox v-model="search" type="search" :placeholder="t.settings.search" icon="search" />
-					</header>
-					<TabBar v-model="currentSettingsRequested" vertical>
-						<Subheader v-if="selfUserInfoStore.isLogined" icon="person">{{ t.settings.user }}</Subheader>
-						<template v-if="selfUserInfoStore.isLogined">
-							<TabItem v-for="setting in settings.personal" :id="setting.id" :key="setting.id" :icon="setting.icon" :to="`/settings/${setting.id}`" @click="showDrawer = false">{{ ti(setting.id) }}</TabItem>
-						</template>
-						<Subheader icon="apps">{{ t.settings.app }}</Subheader>
-						<TabItem v-for="setting in settings.general" :id="setting.id" :key="setting.id" :icon="setting.icon" :to="`/settings/${setting.id}`" @click="showDrawer = false">{{ ti(setting.id) }}</TabItem>
-						<!-- TODO: 使用多语言 -->
-						<Subheader v-if="isAdmin" icon="build_circle">管理设置</Subheader>
-						<template v-if="isAdmin">
-							<TabItem v-for="setting in settings.admin" :id="setting.id" :key="setting.id" :icon="setting.icon" :to="`/settings/${setting.id}`" @click="showDrawer = false">{{ ti(setting.id) }}</TabItem>
-						</template>
-					</TabBar>
-					<div class="nav-bottom-buttons">
-						<template v-if="isAdmin || isDevMode">
-							<Button icon="build" href="/dev">{{ t.development_test_page }}</Button>
-							<Button icon="apps" href="/dev/components">{{ t.components_test_page }}</Button>
-						</template>
-						<Button v-if="selfUserInfoStore.isLogined" icon="logout" @click="logout">{{ t.logout }}</Button>
-					</div>
+					<ScrollContainer overflowX="clip">
+						<header class="title nav-header">
+							<h1>{{ t.settings }}</h1>
+							<TextBox v-model="search" type="search" :placeholder="t.settings.search" icon="search" />
+						</header>
+						<TabBar v-model="currentSettingsRequested" vertical>
+							<Subheader v-if="selfUserInfoStore.isLogined" icon="person">{{ t.settings.user }}</Subheader>
+							<template v-if="selfUserInfoStore.isLogined">
+								<TabItem v-for="setting in settings.personal" :id="setting.id" :key="setting.id" :icon="setting.icon" :to="`/settings/${setting.id}`" @click="showDrawer = false">{{ ti(setting.id) }}</TabItem>
+							</template>
+							<Subheader icon="apps">{{ t.settings.app }}</Subheader>
+							<TabItem v-for="setting in settings.general" :id="setting.id" :key="setting.id" :icon="setting.icon" :to="`/settings/${setting.id}`" @click="showDrawer = false">{{ ti(setting.id) }}</TabItem>
+							<!-- TODO: 使用多语言 -->
+							<Subheader v-if="isAdmin" icon="build_circle">管理设置</Subheader>
+							<template v-if="isAdmin">
+								<TabItem v-for="setting in settings.admin" :id="setting.id" :key="setting.id" :icon="setting.icon" :to="`/settings/${setting.id}`" @click="showDrawer = false">{{ ti(setting.id) }}</TabItem>
+							</template>
+						</TabBar>
+						<div class="nav-bottom-buttons">
+							<template v-if="isAdmin || isDevMode">
+								<Button icon="build" href="/dev">{{ t.development_test_page }}</Button>
+								<Button icon="apps" href="/dev/components">{{ t.components_test_page }}</Button>
+							</template>
+							<Button v-if="selfUserInfoStore.isLogined" icon="logout" @click="logout">{{ t.logout }}</Button>
+						</div>
+					</ScrollContainer>
 				</header>
 			</div>
 		</nav>
@@ -226,24 +228,37 @@
 			display: block !important;
 		}
 
-		> .content > .title.content {
-			display: flex;
-			flex-direction: column;
-			gap: 10px;
-			max-height: 100dvh;
-			padding: 0 $nav-padding-x $nav-padding-x;
-			overflow: hidden overlay;
-			overscroll-behavior-y: contain;
-			scrollbar-gutter: stable; // WARN: Chromium 114 开始，overflow 的 overlay 成了 auto 的别名，因此只能提前占位显示来确保不晃动。目前甚至 Chromium 自己的设置页都在依赖于 overlay，太荒谬了。https://bugs.chromium.org/p/chromium/issues/detail?id=1450927
-			transition: none;
+		.scroll-container {
+			height: 100dvh;
+			padding: 0 $nav-padding-x;
 
 			@include mobile {
-				padding: 0 $mobile-nav-padding-x $mobile-nav-padding-x;
+				padding: 0 $mobile-nav-padding-x;
 			}
 
-			> * {
-				flex-shrink: 0;
+			&:deep(.scroller) {
+				padding-bottom: $nav-padding-x;
+				overscroll-behavior-y: contain;
+
+				> .content {
+					display: flex;
+					flex-direction: column;
+					gap: 10px;
+					transition: none;
+
+					> * {
+						flex-shrink: 0;
+					}
+				}
+
+				@include mobile {
+					padding-bottom: $mobile-nav-padding-x;
+				}
 			}
+		}
+
+		> .content > .title.content {
+			padding: 0;
 		}
 
 		.subheader {

--- a/plugins/scroll.client.ts
+++ b/plugins/scroll.client.ts
@@ -1,0 +1,73 @@
+/*
+ * 滚动修复。
+ * 使用 antfu/vue-router-better-scroller 来记住我们的自定义元素滚动。
+ * plugin 参考：https://github.com/nuxt/movies/blob/main/plugins/scroll.client.ts
+ * 行为参考：https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/pages/runtime/router.options.ts
+ */
+
+import { createRouterScroller } from "vue-router-better-scroller";
+import type { RouteLocationNormalized, RouterScrollBehavior } from "vue-router";
+import { useNuxtApp } from "#app/nuxt";
+import { isChangingPage } from "#app/components/utils";
+import { useRouter } from "#app/composables/router";
+import { appPageTransition as defaultPageTransition } from "#build/nuxt.config.mjs";
+
+type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>;
+
+export default defineNuxtPlugin(({ vueApp }) => {
+	vueApp.use(createRouterScroller({
+		selectors: {
+			".viewport > .scroll-container .scroller"({ to, from, savedPosition }) {
+				const nuxtApp = useNuxtApp();
+				// @ts-expect-error untyped, nuxt-injected option
+				const behavior = useRouter().options?.scrollBehaviorType ?? "auto";
+
+				// By default when the returned position is falsy or an empty object, vue-router will retain the current scroll position
+				// savedPosition is only available for popstate navigations (back button)
+				let position: ScrollPosition = savedPosition || undefined;
+
+				const routeAllowsScrollToTop = typeof to.meta.scrollToTop === "function" ? to.meta.scrollToTop(to, from) : to.meta.scrollToTop;
+
+				// Scroll to top if route is changed by default
+				if (!position && from && to && routeAllowsScrollToTop !== false && isChangingPage(to, from))
+					position = { left: 0, top: 0 };
+
+				// Hash routes on the same page, no page hook is fired so resolve here
+				if (to.path === from.path) {
+					if (from.hash && !to.hash)
+						return { left: 0, top: 0 };
+
+					if (to.hash)
+						return { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior };
+
+					// The route isn't changing so keep current scroll position
+					return false;
+				}
+
+				// Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
+				const hasTransition = (route: RouteLocationNormalized) => !!(route.meta.pageTransition ?? defaultPageTransition);
+				const hookToWait = hasTransition(from) && hasTransition(to) ? "page:transition:finish" : "page:finish";
+				return new Promise(resolve => {
+					nuxtApp.hooks.hookOnce(hookToWait, async () => {
+						await new Promise(resolve => setTimeout(resolve, 0));
+						if (to.hash)
+							position = { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior };
+
+						resolve(position);
+					});
+				});
+			},
+		},
+	}));
+});
+
+function _getHashElementScrollMarginTop(selector: string): number {
+	try {
+		const elem = document.querySelector(selector);
+		if (elem)
+			return (Number.parseFloat(getComputedStyle(elem).scrollMarginTop) || 0) + (Number.parseFloat(getComputedStyle(document.documentElement).scrollPaddingTop) || 0);
+	} catch {
+			// ignore any errors parsing scrollMarginTop
+	}
+	return 0;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         version: 2.0.0(vue@3.4.38(typescript@5.5.4))
       '@vueuse/nuxt':
         specifier: ^11.0.3
-        version: 11.0.3(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
+        version: 11.0.3(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
       axios:
         specifier: ^1.7.5
         version: 1.7.5
@@ -109,6 +109,9 @@ importers:
       vue-cropper:
         specifier: ^1.1.4
         version: 1.1.4
+      vue-router-better-scroller:
+        specifier: ^0.0.0
+        version: 0.0.0(vue-router@4.4.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4))
       vue-virtual-scroller:
         specifier: 2.0.0-beta.8
         version: 2.0.0-beta.8(vue@3.4.38(typescript@5.5.4))
@@ -130,7 +133,7 @@ importers:
         version: 1.35.0
       '@nuxt/content':
         specifier: ^2.13.2
-        version: 2.13.2(ioredis@5.4.1)(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
+        version: 2.13.2(ioredis@5.4.1)(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
       '@nuxt/kit':
         specifier: ^3.13.0
         version: 3.13.0(magicast@0.3.4)(rollup@4.21.0)
@@ -184,7 +187,7 @@ importers:
         version: 9.0.0
       nuxt:
         specifier: ^3.13.0
-        version: 3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
+        version: 3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
       nuxt-lodash:
         specifier: ^2.5.3
         version: 2.5.3(magicast@0.3.4)(rollup@4.21.0)
@@ -1005,79 +1008,67 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1303,35 +1294,30 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.4.1':
     resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.4.1':
     resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.4.1':
     resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.4.1':
     resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.4.1':
     resolution: {integrity: sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==}
@@ -1524,55 +1510,46 @@ packages:
     resolution: {integrity: sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.0':
     resolution: {integrity: sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.21.0':
     resolution: {integrity: sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.21.0':
     resolution: {integrity: sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.0':
     resolution: {integrity: sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.0':
     resolution: {integrity: sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.21.0':
     resolution: {integrity: sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.21.0':
     resolution: {integrity: sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.21.0':
     resolution: {integrity: sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==}
@@ -5921,6 +5898,12 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  vue-router-better-scroller@0.0.0:
+    resolution: {integrity: sha512-E+ovMBUOgr0TU6rYnc5X8h7rlu+QUkK2AMBXt2S6yMrAlW86cq6k5OExM4WnL4vfHbmJEtf+SbAtZ3H3bxYoBQ==}
+    peerDependencies:
+      vue: ^3.3.4
+      vue-router: ^4.2.2
+
   vue-router@4.4.3:
     resolution: {integrity: sha512-sv6wmNKx2j3aqJQDMxLFzs/u/mjA9Z5LCgy6BE0f7yFWMjrPLnS/sPNn8ARY/FXw6byV18EFutn5lTO6+UsV5A==}
     peerDependencies:
@@ -6933,13 +6916,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nuxt/content@2.13.2(ioredis@5.4.1)(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))':
+  '@nuxt/content@2.13.2(ioredis@5.4.1)(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.0)
       '@nuxtjs/mdc': 0.8.3(magicast@0.3.4)(rollup@4.21.0)
       '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.5.4))
       '@vueuse/head': 2.0.0(vue@3.4.38(typescript@5.5.4))
-      '@vueuse/nuxt': 10.11.1(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
+      '@vueuse/nuxt': 10.11.1(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
@@ -7160,7 +7143,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/vite-builder@3.13.0(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vue@3.4.38(typescript@5.5.4))':
+  '@nuxt/vite-builder@3.13.0(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vue@3.4.38(typescript@5.5.4))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.0)
       '@rollup/plugin-replace': 5.0.7(rollup@4.21.0)
@@ -7193,7 +7176,7 @@ snapshots:
       unplugin: 1.12.2
       vite: 5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)
       vite-node: 2.0.5(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)
-      vite-plugin-checker: 0.7.2(eslint@9.9.1(jiti@1.21.6))(meow@13.2.0)(optionator@0.9.4)(stylelint@16.8.2(typescript@5.5.4))(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
+      vite-plugin-checker: 0.7.2(eslint@9.9.1(jiti@1.21.6))(optionator@0.9.4)(stylelint@16.8.2(typescript@5.5.4))(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
       vue: 3.4.38(typescript@5.5.4)
       vue-bundle-renderer: 2.1.0
     transitivePeerDependencies:
@@ -8212,13 +8195,13 @@ snapshots:
 
   '@vueuse/metadata@9.13.0': {}
 
-  '@vueuse/nuxt@10.11.1(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))':
+  '@vueuse/nuxt@10.11.1(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.0)
       '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.5.4))
       '@vueuse/metadata': 10.11.1
       local-pkg: 0.5.0
-      nuxt: 3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
+      nuxt: 3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
       vue-demi: 0.14.10(vue@3.4.38(typescript@5.5.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -8227,13 +8210,13 @@ snapshots:
       - supports-color
       - vue
 
-  '@vueuse/nuxt@11.0.3(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))':
+  '@vueuse/nuxt@11.0.3(magicast@0.3.4)(nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)))(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.0)
       '@vueuse/core': 11.0.3(vue@3.4.38(typescript@5.5.4))
       '@vueuse/metadata': 11.0.3
       local-pkg: 0.5.0
-      nuxt: 3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
+      nuxt: 3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
       vue-demi: 0.14.10(vue@3.4.38(typescript@5.5.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -10973,14 +10956,14 @@ snapshots:
       - rollup
       - supports-color
 
-  nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)):
+  nuxt@3.13.0(@parcel/watcher@2.4.1)(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(ioredis@5.4.1)(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 1.3.14(rollup@4.21.0)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6))
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.0)
       '@nuxt/schema': 3.13.0(rollup@4.21.0)
       '@nuxt/telemetry': 2.5.4(magicast@0.3.4)(rollup@4.21.0)
-      '@nuxt/vite-builder': 3.13.0(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(less@4.2.0)(magicast@0.3.4)(meow@13.2.0)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vue@3.4.38(typescript@5.5.4))
+      '@nuxt/vite-builder': 3.13.0(@types/node@22.5.0)(eslint@9.9.1(jiti@1.21.6))(less@4.2.0)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.21.0)(sass@1.77.6)(stylelint@16.8.2(typescript@5.5.4))(stylus@0.63.0)(terser@5.31.6)(typescript@5.5.4)(vue@3.4.38(typescript@5.5.4))
       '@unhead/dom': 1.10.0
       '@unhead/ssr': 1.10.0
       '@unhead/vue': 1.10.0(vue@3.4.38(typescript@5.5.4))
@@ -12834,7 +12817,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.7.2(eslint@9.9.1(jiti@1.21.6))(meow@13.2.0)(optionator@0.9.4)(stylelint@16.8.2(typescript@5.5.4))(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)):
+  vite-plugin-checker@0.7.2(eslint@9.9.1(jiti@1.21.6))(optionator@0.9.4)(stylelint@16.8.2(typescript@5.5.4))(typescript@5.5.4)(vite@5.4.2(@types/node@22.5.0)(less@4.2.0)(sass@1.77.6)(stylus@0.63.0)(terser@5.31.6)):
     dependencies:
       '@babel/code-frame': 7.24.7
       ansi-escapes: 4.3.2
@@ -12853,7 +12836,6 @@ snapshots:
       vscode-uri: 3.0.8
     optionalDependencies:
       eslint: 9.9.1(jiti@1.21.6)
-      meow: 13.2.0
       optionator: 0.9.4
       stylelint: 16.8.2(typescript@5.5.4)
       typescript: 5.5.4
@@ -12974,6 +12956,11 @@ snapshots:
   vue-resize@2.0.0-alpha.1(vue@3.4.38(typescript@5.5.4)):
     dependencies:
       vue: 3.4.38(typescript@5.5.4)
+
+  vue-router-better-scroller@0.0.0(vue-router@4.4.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4)):
+    dependencies:
+      vue: 3.4.38(typescript@5.5.4)
+      vue-router: 4.4.3(vue@3.4.38(typescript@5.5.4))
 
   vue-router@4.4.3(vue@3.4.38(typescript@5.5.4)):
     dependencies:


### PR DESCRIPTION
引入我自己写的滚动条，不再使用各家标准混乱的浏览器/系统滚动条，可以完美解决#206、#234、#261、#289、#298。

逻辑和样式鼠标参照Windows 11、macOS，触摸屏参照iOS，使用`isMobile()`区分鼠标和触摸屏。
鼠标状态下的细微调整按钮将会在之后进行实现并提供开关，本PR仅实现基本功能。

提交的比较乱，之后squash merge。
请各位进行测试，如果有改进建议或者发现bug在直接在这里说。
测试页面地址：https://kirakira-cerasus-33nfl8lns-kirakira.vercel.app/