### PR TITLE
fix(player-video): fix initial player height

### DIFF
--- a/components/Player/PlayerVideo/PlayerVideo.vue
+++ b/components/Player/PlayerVideo/PlayerVideo.vue
@@ -782,6 +782,7 @@
 
 			& video {
 				max-height: calc(100dvh - 36px - 26px * 2);
+				aspect-ratio: 16 / 9;
 			}
 		}
 


### PR DESCRIPTION
初始播放器高度太低，強制設定`aspect-ratio: 16 / 9;`嘗試修正此問題

before:
<img width="2295" height="705" alt="image" src="https://github.com/user-attachments/assets/63d4823e-f931-476a-9554-f1ee0aac4b18" />

after:
<img width="2367" height="1265" alt="image" src="https://github.com/user-attachments/assets/26c193a3-4833-4d5d-b521-3cc2efb349e1" />
