### PR TITLE
hotfix(position control): 触摸屏很难拖动滑块

### DIFF
--- a/components/PositionControl.vue
+++ b/components/PositionControl.vue
@@ -137,6 +137,7 @@
 		writing-mode: horizontal-tb;
 		background-color: c(inset-bg);
 		background-clip: padding-box;
+		touch-action: none;
 
 		&::after { // Intercept pointer events.
 			content: "";


### PR DESCRIPTION
紧急修复：触摸屏用户很难在背景图像的位置设置中拖动滑块。