### PR TITLE
Change backend port to `30000`

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ pnpm dev-stg
 一个典型的自定义启动命令看起来像：
 ```bash
 # 以下命令等价于 'pnpm dev-local'
-pnpm cross-env VITE_BACKEND_URI=https://localhost:9999 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxi dev --host --https --ssl-cert server/server.cer --ssl-key server/server.key
+pnpm cross-env VITE_BACKEND_URI=https://localhost:30000 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxi dev --host --https --ssl-cert server/server.cer --ssl-key server/server.key
 ```
 
 启动后，您应该能够在这个地址访问：https://localhost:3000/
@@ -210,8 +210,8 @@ pnpm cross-env VITE_BACKEND_URI=https://localhost:9999 VITE_CLOUDFLARE_IMAGES_PR
 上述命令的解析：
 1. `cross-env`\
   设置跨平台的环境变量，确保命令在不同操作系统（如 Windows 和 Linux）下都能正常执行。
-2. `VITE_BACKEND_URI=https://localhost:9999`\
-  注入一个名为 `VITE_BACKEND_URI` 的环境变量，其值为 `https://localhost:9999`，即后端 API 的 URI。
+2. `VITE_BACKEND_URI=https://localhost:3000`\
+  注入一个名为 `VITE_BACKEND_URI` 的环境变量，其值为 `https://localhost:3000`，即后端 API 的 URI。
 3. `VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg`\
   注入一个名为 `VITE_CLOUDFLARE_IMAGES_PROVIDER` 的环境变量，其值为 `cloudflare-stg`。\
   这代表您使用名为 `cloudflare-stg` 的 [NuxtImage Custom Provider](https://image.nuxt.com/advanced/custom-provider)。\

--- a/README_en-US.md
+++ b/README_en-US.md
@@ -199,7 +199,7 @@ Sometimes, the preset quick start command does not meet your needs. In this case
 A typical custom startup command looks like:
 ```bash
 # The following command is equivalent to 'pnpm dev-local'
-pnpm cross-env VITE_BACKEND_URI=https://localhost:9999 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxi dev --host --https --ssl-cert server/server.cer --ssl-key server/server.key
+pnpm cross-env VITE_BACKEND_URI=https://localhost:30000 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxi dev --host --https --ssl-cert server/server.cer --ssl-key server/server.key
 ```
 
 After it started, you should be able to preview at this URL: https://localhost:3000/
@@ -207,8 +207,8 @@ After it started, you should be able to preview at this URL: https://localhost:3
 Parsing of the above command:
 1. `cross-env`\
 Set cross-platform environment variables to ensure that the command can be executed normally under different operating systems (such as Windows and Linux).
-2. `VITE_BACKEND_URI=https://localhost:9999`\
-Injects an environment variable named `VITE_BACKEND_URI` with the value `https://localhost:9999`, which is the URI of the backend API.
+2. `VITE_BACKEND_URI=https://localhost:30000`\
+Injects an environment variable named `VITE_BACKEND_URI` with the value `https://localhost:30000`, which is the URI of the backend API.
 3. `VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg`\
 Injects an environment variable named `VITE_CLOUDFLARE_IMAGES_PROVIDER` with the value `cloudflare-stg`. \
 This indicates that you are using the [NuxtImage Custom Provider](https://image.nuxt.com/advanced/custom-provider) named `cloudflare-stg`. \

--- a/docs/port.md
+++ b/docs/port.md
@@ -10,7 +10,7 @@ https://localhost:4000/ -->
 https://localhost:9000/ -->
 
 ## [KIRAKIRA-Rosales](https://github.com/KIRAKIRA-DOUGA/KIRAKIRA-Rosales)
-https://localhost:9999/
+https://localhost:30000/
 
 ## KIRAKIRA-I18n-Editor
 https://localhost:5000/

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 	"author": "KIRAKIRA Project Team",
 	"scripts": {
 		"dev-local": "cross-env pnpm run dev-local-stg",
-		"dev-local-stg": "cross-env VITE_BACKEND_URI=https://localhost:9999 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxt dev --host",
-		"dev-local-prod": "cross-env VITE_BACKEND_URI=https://localhost:9999 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-prod VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-yvgxn6arnuae3q89.cloudflarestream.com/ nuxt dev --host",
+		"dev-local-stg": "cross-env VITE_BACKEND_URI=https://localhost:30000 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxt dev --host",
+		"dev-local-prod": "cross-env VITE_BACKEND_URI=https://localhost:30000 VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-prod VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-yvgxn6arnuae3q89.cloudflarestream.com/ nuxt dev --host",
 		"dev-stg": "cross-env VITE_BACKEND_URI=https://localhost:3000/api/staging VITE_CLOUDFLARE_IMAGES_PROVIDER=cloudflare-stg VITE_CLOUDFLARE_STREAM_CUSTOMER_SUBDOMAIN=https://customer-o9xrvgnj5fidyfm4.cloudflarestream.com/ nuxt dev --host",
 		"build": "nuxt build",
 		"generate": "nuxt generate",

--- a/utils/environment.ts
+++ b/utils/environment.ts
@@ -12,7 +12,7 @@ export const environment = {
 	get development() { return process.env.NODE_ENV === "development"; },
 	/** 后端接口 URI 地址 */
 	get backendUri() {
-		const DEFAULT_BACKEND_URI = "https://localhost:9999/";
+		const DEFAULT_BACKEND_URI = "https://localhost:30000/";
 		try {
 			const backendUriInput = import.meta.env.VITE_BACKEND_URI;
 			if (!backendUriInput) {


### PR DESCRIPTION
Change the default port of the backend to `30000` to prevent the previous port `9999` from being occupied by other programs or unusable due to being reserved for other programs.

This feature should only apply to local development and should not affect the stg and prod environments.
If you are using a local backend, after merging this PR, please make sure that the backend environment variables are set correctly:
``` powershell
# Example of PowerShell
SERVER_PORT="30000"
```
Related RP in backend repo: https://github.com/KIRAKIRA-DOUGA/KIRAKIRA-Rosales/pull/112 (Merged)